### PR TITLE
Add Integration Tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,22 @@ docker-compose -f docker-compose-installed.yaml up --build
 Note that this compose file only exposes the URL for the Marketplace REST API,
 not Sawtooth or RethinkDB.
 
+## Testing
+
+Integration tests can be run within docker containers using this command:
+
+```bash
+bin/run_integration_tests
+```
+
+By default this command will run all tests in the `integration_tests/`
+directory. It is also possible to run a single set of tests by specifying a
+sub-directory:
+
+```bash
+bin/run_integration_tests rest_api
+```
+
 ## License
 
 Hyperledger Sawtooth software is licensed under the

--- a/bin/run_integration_tests
+++ b/bin/run_integration_tests
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# -----------------------------------------------------------------------------
+
+set -e
+
+TOP_DIR=$(cd $(dirname $(dirname $0)) && pwd)
+TEST_DIR="integration_tests"
+
+run_test() {
+  cd $TOP_DIR/$TEST_DIR/$1
+
+  docker-compose up --abort-on-container-exit
+  docker-compose down
+
+  cd -
+}
+
+if [ -z $1 ]
+then
+  for t in $( ls $TEST_DIR )
+  do
+    run_test $t
+  done
+
+else
+  run_test $1
+
+fi

--- a/integration_tests/rest_api/Dockerfile
+++ b/integration_tests/rest_api/Dockerfile
@@ -14,24 +14,14 @@
 # -----------------------------------------------------------------------------
 
 FROM node:6
-WORKDIR /project/sawbuck_app
-COPY package.json .
-RUN npm install
-COPY . .
-RUN npm run build
 
-FROM httpd:2.4
-WORKDIR .
-COPY --from=0 /project/sawbuck_app/public/ /usr/local/apache2/htdocs/
+RUN apt-get update && \
+    apt-get install -y --allow-unauthenticated -q python3-pip
 
-RUN echo "\
-\n\
-ServerName sawbuck_app\n\
-LoadModule proxy_module modules/mod_proxy.so\n\
-LoadModule proxy_http_module modules/mod_proxy_http.so\n\
-ProxyPass /api http://market-rest-api:8040\n\
-ProxyPassReverse /api http://market-rest-api:8040\n\
-\n\
-" >>/usr/local/apache2/conf/httpd.conf
+RUN npm install -g dredd
 
-EXPOSE 80/tcp
+RUN pip3 install \
+    requests \
+    dredd-hooks
+
+WORKDIR /project/sawtooth-marketplace

--- a/integration_tests/rest_api/docker-compose.yaml
+++ b/integration_tests/rest_api/docker-compose.yaml
@@ -50,6 +50,9 @@ services:
       PYTHONPATH: /project/sawtooth-marketplace/addressing
     command: |
       dredd ./rest_api/api-spec.yaml http://market-rest-api:8040
+        --language=python
+        --hookfiles=./integration_tests/rest_api/*_hooks.py
+        --hooks-worker-after-connect-wait=10000
         --reporter=dot
 
   market-processor:

--- a/integration_tests/rest_api/docker-compose.yaml
+++ b/integration_tests/rest_api/docker-compose.yaml
@@ -1,0 +1,127 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# -----------------------------------------------------------------------------
+
+version: "2.1"
+
+services:
+
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+version: '2.1'
+
+services:
+  market-rest-api-env:
+    build:
+      context: ../../
+      dockerfile: ./integration_tests/rest_api/Dockerfile
+    image: market-rest-api-test-env
+    depends_on:
+      - market-rest-api
+      - market-ledger-sync
+      - market-processor
+    volumes:
+      - '../../:/project/sawtooth-marketplace'
+    environment:
+      PYTHONPATH: /project/sawtooth-marketplace/addressing
+    command: |
+      dredd ./rest_api/api-spec.yaml http://market-rest-api:8040
+        --reporter=dot
+
+  market-processor:
+    build:
+      context: ../../
+      dockerfile: ./processor/Dockerfile
+      args:
+        - http_proxy
+        - https_proxy
+        - no_proxy
+    image: market-tp
+    volumes:
+      - '../../:/project/sawtooth-marketplace'
+    command: echo "No transaction processor command set"
+
+  market-rest-api:
+    build:
+      context: ../../
+      dockerfile: ./rest_api/Dockerfile
+      args:
+        - http_proxy
+        - https_proxy
+        - no_proxy
+    image: market-rest-api
+    volumes:
+      - ../../:/project/sawtooth-marketplace
+    depends_on:
+      - market-ledger-sync
+      - rethink
+      - validator
+    command: echo "No REST API command set"
+
+  market-ledger-sync:
+    build:
+      context: ../../
+      dockerfile: ./ledger_sync/Dockerfile
+      args:
+        - http_proxy
+        - https_proxy
+        - no_proxy
+    image: market-ledger-sync
+    volumes:
+      - ../../:/project/sawtooth-marketplace
+    depends_on:
+      - rethink
+      - validator
+    command: echo "No ledger sync command set"
+
+  rethink:
+    image: rethinkdb:2.3
+    expose:
+      - 8080
+      - 28015
+
+  settings-tp:
+    image: hyperledger/sawtooth-settings-tp:1.0
+    depends_on:
+      - validator
+    command: settings-tp -vv --connect tcp://validator:4004
+
+  validator:
+    image: hyperledger/sawtooth-validator:1.0
+    expose:
+      - 4004
+    command: |
+      bash -c "
+        sawadm keygen && \
+        sawtooth keygen my_key && \
+        sawset genesis -k /root/.sawtooth/keys/my_key.priv && \
+        sawadm genesis config-genesis.batch && \
+        sawtooth-validator -vv \
+          --endpoint tcp://validator:8800 \
+          --bind component:tcp://eth0:4004 \
+          --bind network:tcp://eth0:8800
+      "

--- a/integration_tests/rest_api/setup_data_hooks.py
+++ b/integration_tests/rest_api/setup_data_hooks.py
@@ -1,0 +1,103 @@
+
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# -----------------------------------------------------------------------------
+
+import re
+import json
+import dredd_hooks as hooks
+from requests import request
+
+
+INVALID_SPEC_IDS = [
+        ('account',
+         '02178c1bcdb25407394348f1ff5273adae287d8ea328184546837957e71c7de57a')
+]
+
+ACCOUNT = {
+    'email': 'suzie72@suze.au.co',
+    'password': '12345'
+}
+
+
+seeded_data = {}
+
+
+def get_base_api_url(txn):
+    protocol = txn.get('protocol', 'http:')
+    host = txn.get('host', 'localhost')
+    port = txn.get('port', '8000')
+    return '{}//{}:{}/'.format(protocol, host, port)
+
+def api_request(method, base_url, path, body=None, auth=None):
+    url = base_url + path
+
+    auth = auth or seeded_data.get('auth', None)
+    headers = {'Authorization': auth} if auth else None
+
+    response = request(method, url, json=body, headers=headers)
+    response.raise_for_status()
+
+    parsed = response.json()
+    return parsed.get('data', parsed)
+
+
+def api_submit(base_url, path, resource, auth=None):
+    return api_request('POST', base_url, path, body=resource, auth=auth)
+
+
+def patch_body(txn, update):
+    old_body = json.loads(txn['request']['body'])
+
+    new_body = {}
+    for key, value in old_body.items():
+        new_body[key] = value
+    for key, value in update.items():
+        new_body[key] = value
+
+    txn['request']['body'] = json.dumps(new_body)
+
+
+def sub_nested_strings(dct, pattern, replacement):
+    for key in dct.keys():
+        if isinstance(dct[key], dict):
+            sub_nested_strings(dct[key], pattern, replacement)
+        elif isinstance(dct[key], str):
+            dct[key] = re.sub(pattern, replacement, dct[key])
+
+
+@hooks.before_all
+def initialize_sample_resources(txns):
+    base_url = get_base_api_url(txns[0])
+    submit = lambda p, r, a=None: api_submit(base_url, p, r, a)
+
+    # Create ACCOUNT
+    account_response = submit('accounts', ACCOUNT)
+    seeded_data['auth'] = account_response['authorization']
+    seeded_data['account'] = account_response['account']
+
+    # Replace example auth and identifiers with ones from seeded data
+    for txn in txns:
+        txn['request']['headers']['Authorization'] = seeded_data['auth']
+
+        for name, spec_id in INVALID_SPEC_IDS:
+            sub_nested_strings(txn, spec_id, seeded_data[name]['id'])
+
+
+@hooks.before('/authorization > POST > 200 > application/json')
+def add_credentials(txn):
+    patch_body(txn, {
+        'email': ACCOUNT['email'],
+        'password': ACCOUNT['password']
+    })

--- a/sawbuck_app/Dockerfile
+++ b/sawbuck_app/Dockerfile
@@ -23,8 +23,8 @@ RUN echo "\
 ServerName sawbuck_app\n\
 LoadModule proxy_module modules/mod_proxy.so\n\
 LoadModule proxy_http_module modules/mod_proxy_http.so\n\
-ProxyPass /api http://market-rest-api:8008\n\
-ProxyPassReverse /api http://market-rest-api:8008\n\
+ProxyPass /api http://market-rest-api:8040\n\
+ProxyPassReverse /api http://market-rest-api:8040\n\
 \n\
 " >>/usr/local/apache2/conf/httpd.conf
 


### PR DESCRIPTION
Adds integration tests based on `api-spec.yaml`. Will not run without a REST API, TP, and LedgerSync to test against, but should correctly test both the `POST /authorization` and `POST /accounts` routes once those components are merged.