### PR TITLE
TP create account

### DIFF
--- a/bin/protogen
+++ b/bin/protogen
@@ -80,3 +80,4 @@ if __name__ == '__main__':
     make_protobuf('processor', 'marketplace_processor/protobuf')
     make_protobuf('server', 'marketplace_rest_api/protobuf')
     make_protobuf('ledger_sync', 'marketplace_ledger_sync/protobuf')
+    make_protobuf('transaction_creation', 'marketplace_transaction/protobuf')

--- a/bin/run_lint
+++ b/bin/run_lint
@@ -41,4 +41,8 @@ lint processor/marketplace_processor || ret_val=1
 export PYTHONPATH=$TOP_DIR/addressing:$TOP_DIR/ledger_sync
 lint ledger_sync/marketplace_ledger_sync || ret_val=1
 
+export PYTHONPATH=$TOP_DIR/addressing
+lint transaction_creation/marketplace_transaction || ret_val=1
+
+
 exit $ret_val

--- a/dev-tools/Dockerfile
+++ b/dev-tools/Dockerfile
@@ -23,6 +23,8 @@ RUN echo "deb apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 
     apt-get install -y --allow-unauthenticated -q \
         python3-pip \
         python3-sawtooth-sdk \
+        python3-sawtooth-rest-api \
+        python3-sawtooth-cli \
         curl
 
 RUN curl -sL https://deb.nodesource.com/setup_6.x | bash - \

--- a/integration_tests/blockchain/__init__.py
+++ b/integration_tests/blockchain/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# -----------------------------------------------------------------------------

--- a/integration_tests/blockchain/blockchain_integration_test.py
+++ b/integration_tests/blockchain/blockchain_integration_test.py
@@ -1,0 +1,145 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# -----------------------------------------------------------------------------
+
+import logging
+import time
+import unittest
+from urllib.request import urlopen
+from urllib.error import HTTPError
+from urllib.error import URLError
+from uuid import uuid4
+
+from sawtooth_cli.rest_client import RestClient
+
+from sawtooth_signing import create_context
+from sawtooth_signing import CryptoFactory
+
+from marketplace_transaction import transaction_creation
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+def make_key():
+    context = create_context('secp256k1')
+    private_key = context.new_random_private_key()
+    signer = CryptoFactory(context).new_signer(private_key)
+    return signer
+
+
+REST_URL = 'rest-api:8008'
+
+
+BATCH_KEY = make_key()
+
+
+class BlockchainTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        wait_for_rest_apis([REST_URL])
+        cls.client = MarketplaceClient(REST_URL)
+
+        cls.key1 = make_key()
+
+    def test_00_create_account(self):
+        """Tests the CreateAccount validation rules.
+
+        Notes:
+            CreateAccount validation rules
+                - The public_key is unique for all accounts.
+        """
+
+        self.assertEqual(
+            self.client.create_account(
+                key=self.key1,
+                label=uuid4().hex,
+                description=uuid4().hex)[0]['status'],
+            "COMMITTED")
+
+        self.assertEqual(
+            self.client.create_account(
+                key=self.key1,
+                label=uuid4().hex,
+                description=uuid4().hex)[0]['status'],
+            "INVALID",
+            "There can only be 1 account per public key.")
+
+
+class MarketplaceClient(object):
+
+    def __init__(self, url):
+        self._client = RestClient(base_url="http://{}".format(url))
+
+    def create_account(self, key, label, description):
+        batch_list, signature = transaction_creation.create_account(
+            txn_key=key,
+            batch_key=BATCH_KEY,
+            label=label,
+            description=description)
+        self._client.send_batches(batch_list)
+        return self._client.get_statuses([signature], wait=10)
+
+
+def wait_until_status(url, status_code=200, tries=5):
+    """Pause the program until the given url returns the required status.
+    Args:
+        url (str): The url to query.
+        status_code (int, optional): The required status code. Defaults to 200.
+        tries (int, optional): The number of attempts to request the url for
+            the given status. Defaults to 5.
+    Raises:
+        AssertionError: If the status is not received in the given number of
+            tries.
+    """
+    attempts = tries
+    while attempts > 0:
+        try:
+            response = urlopen(url)
+            if response.getcode() == status_code:
+                return
+
+        except HTTPError as err:
+            if err.code == status_code:
+                return
+
+            LOGGER.debug('failed to read url: %s', str(err))
+        except URLError as err:
+            LOGGER.debug('failed to read url: %s', str(err))
+
+        sleep_time = (tries - attempts + 1) * 2
+        LOGGER.debug('Retrying in %s secs', sleep_time)
+        time.sleep(sleep_time)
+
+        attempts -= 1
+
+    raise AssertionError(
+        "{} is not available within {} attempts".format(url, tries))
+
+
+def wait_for_rest_apis(endpoints, tries=5):
+    """Pause the program until all the given REST API endpoints are available.
+    Args:
+        endpoints (list of str): A list of host:port strings.
+        tries (int, optional): The number of attempts to request the url for
+            availability.
+    """
+    for endpoint in endpoints:
+        http = 'http://'
+        url = endpoint if endpoint.startswith(http) else http + endpoint
+        wait_until_status(
+            '{}/blocks'.format(url),
+            status_code=200,
+            tries=tries)

--- a/integration_tests/blockchain/docker-compose.yaml
+++ b/integration_tests/blockchain/docker-compose.yaml
@@ -1,0 +1,65 @@
+# Copyright 2017 Intel Corpora# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# -----------------------------------------------------------------------------
+
+version: '2.1'
+
+services:
+  market-processor:
+    build:
+      context: ../..
+      dockerfile: ./processor/Dockerfile
+      args:
+        - http_proxy
+        - https_proxy
+        - no_proxy
+    volumes:
+      - '../..:/project/sawtooth-marketplace'
+    command: ./bin/marketplace-tp -vv -C tcp://validator:4004
+
+  settings-tp:
+    image: hyperledger/sawtooth-settings-tp:1.0
+    depends_on:
+      - validator
+    command: settings-tp -vv --connect tcp://validator:4004
+
+  validator:
+    image: hyperledger/sawtooth-validator:1.0
+    expose:
+      - 4004
+    command: |
+      bash -c "
+        sawadm keygen &&
+        sawtooth keygen my_key &&
+        sawset genesis -k /root/.sawtooth/keys/my_key.priv &&
+        sawadm genesis config-genesis.batch && 
+        sawtooth-validator -vv \
+          --endpoint tcp://validator:8800 \
+          --bind component:tcp://eth0:4004 \
+          --bind network:tcp://eth0:8800
+      "
+
+  rest-api:
+    image: hyperledger/sawtooth-rest-api:1.0
+    entrypoint: sawtooth-rest-api -vv --connect tcp://validator:4004 --bind rest-api:8008
+
+  test-runner:
+    build:
+      context: ../../
+      dockerfile: ./dev-tools/Dockerfile
+    volumes:
+      - '../../:/project/sawtooth-marketplace'
+    command: bash -c "cd integration_tests/blockchain && python3 -m nose2 -v blockchain_integration_test"
+    environment:
+      PYTHONPATH: /project/sawtooth-marketplace/addressing:/project/sawtooth-marketplace/transaction_creation

--- a/processor/marketplace_processor/account/__init__.py
+++ b/processor/marketplace_processor/account/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# -----------------------------------------------------------------------------

--- a/processor/marketplace_processor/account/account_creation.py
+++ b/processor/marketplace_processor/account/account_creation.py
@@ -1,0 +1,40 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# -----------------------------------------------------------------------------
+
+from sawtooth_sdk.processor.exceptions import InvalidTransaction
+
+
+def handle_account_creation(create_account, header, state):
+    """Handles creating an Account.
+
+    Args:
+        create_account (CreateAccount): The transaction.
+        header (TransactionHeader): The header of the Transaction.
+        state (MarketplaceState): The wrapper around the Context.
+
+    Raises:
+        InvalidTransaction
+            - The public key already exists for an Account.
+    """
+
+    if state.get_account(public_key=header.signer_public_key):
+        raise InvalidTransaction("Account with public key {} already "
+                                 "exists".format(header.signer_public_key))
+
+    state.set_account(
+        public_key=header.signer_public_key,
+        label=create_account.label,
+        description=create_account.description,
+        holdings=[])

--- a/processor/marketplace_processor/handler.py
+++ b/processor/marketplace_processor/handler.py
@@ -17,6 +17,10 @@ from sawtooth_sdk.processor.handler import TransactionHandler
 
 from marketplace_addressing import addresser
 
+from marketplace_processor.account import account_creation
+from marketplace_processor.marketplace_payload import MarketplacePayload
+from marketplace_processor.marketplace_state import MarketplaceState
+
 
 class MarketplaceHandler(TransactionHandler):
 
@@ -33,4 +37,12 @@ class MarketplaceHandler(TransactionHandler):
         return ['1.0']
 
     def apply(self, transaction, context):
-        pass
+
+        state = MarketplaceState(context=context, timeout=2)
+        payload = MarketplacePayload(payload=transaction.payload)
+
+        if payload.create_account():
+            account_creation.handle_account_creation(
+                payload.create_account(),
+                header=transaction.header,
+                state=state)

--- a/processor/marketplace_processor/marketplace_payload.py
+++ b/processor/marketplace_processor/marketplace_payload.py
@@ -1,0 +1,47 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# -----------------------------------------------------------------------------
+
+from marketplace_processor.protobuf import payload_pb2
+
+
+class MarketplacePayload(object):
+
+    def __init__(self, payload):
+        self._transaction = payload_pb2.TransactionPayload()
+        self._transaction.ParseFromString(payload)
+
+    def create_account(self):
+        """Returns the value set in the create_account.
+
+        Used for both checking that the CreateAccount transaction exists
+        and returning that txn.
+
+        Returns:
+            payload_pb2.CreateAccount
+        """
+
+        return self._transaction.create_account
+
+    def create_holding(self):
+        """Returns the value set in the create_holding.
+
+        Used for both checking that the CreateHolding transaction exists
+        and returning the txn.
+
+        Returns:
+            payload_pb2.CreateHolding
+        """
+
+        return self._transaction.create_holding

--- a/processor/marketplace_processor/marketplace_state.py
+++ b/processor/marketplace_processor/marketplace_state.py
@@ -1,0 +1,94 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# -----------------------------------------------------------------------------
+
+from marketplace_addressing import addresser
+from marketplace_processor.protobuf import account_pb2
+
+
+class MarketplaceState(object):
+
+    def __init__(self, context, timeout=2):
+        self._context = context
+        self._timeout = timeout
+        self._state_entries = None
+
+    def get_account(self, public_key):
+        address = addresser.make_account_address(account_id=public_key)
+
+        self._state_entries = self._context.get_state(
+            addresses=[address],
+            timeout=self._timeout)
+
+        container = _get_account_container(self._state_entries, address)
+        account = None
+        try:
+            account = _get_account_from_container(
+                container,
+                identifier=public_key)
+        except KeyError:
+            # We are fine with returning None for an account that doesn't
+            # exist in state.
+            pass
+        return account
+
+    def set_account(self, public_key, label, description, holdings):
+        address = addresser.make_account_address(account_id=public_key)
+
+        container = _get_account_container(self._state_entries, address)
+
+        try:
+            account = _get_account_from_container(
+                container,
+                public_key)
+        except KeyError:
+            account = container.entries.add()
+
+        account.public_key = public_key
+        account.label = label
+        account.description = description
+        for holding in holdings:
+            account.holdings.append(holding)
+
+        state_entries_send = {}
+        state_entries_send[address] = container.SerializeToString()
+        return self._context.set_state(
+            state_entries_send,
+            self._timeout)
+
+
+def _get_account_container(state_entries, address):
+    try:
+        entry = _find_in_state(state_entries, address)
+        container = account_pb2.AccountContainer()
+        container.ParseFromString(entry.data)
+    except KeyError:
+        container = account_pb2.AccountContainer()
+
+    return container
+
+
+def _get_account_from_container(container, identifier):
+    for account in container.entries:
+        if account.public_key == identifier:
+            return account
+    raise KeyError(
+        "Account with identifier {} is not in container.".format(identifier))
+
+
+def _find_in_state(state_entries, address):
+    for entry in state_entries:
+        if entry.address == address:
+            return entry
+    raise KeyError("Address {} not found in state".format(address))

--- a/transaction_creation/marketplace_transaction/__init__.py
+++ b/transaction_creation/marketplace_transaction/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# -----------------------------------------------------------------------------

--- a/transaction_creation/marketplace_transaction/common.py
+++ b/transaction_creation/marketplace_transaction/common.py
@@ -1,0 +1,90 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# -----------------------------------------------------------------------------
+
+import hashlib
+from uuid import uuid4
+
+from sawtooth_rest_api.protobuf import batch_pb2
+from sawtooth_rest_api.protobuf import transaction_pb2
+
+from marketplace_addressing import addresser
+
+
+def wrap_payload_in_txn_batch(txn_key, payload, header, batch_key):
+    """Takes the serialized RBACPayload and creates a batch_list, batch
+    signature tuple.
+    Args:
+        txn_key (sawtooth_signing.Signer): The txn signer's key pair.
+        payload (bytes): The serialized RBACPayload.
+        header (bytes): The serialized TransactionHeader.
+        batch_key (sawtooth_signing.Signer): The batch signer's key pair.
+    Returns:
+        tuple
+            The zeroth element is a BatchList, and the first element is
+            the batch header_signature.
+    """
+
+    transaction = transaction_pb2.Transaction(
+        payload=payload,
+        header=header,
+        header_signature=txn_key.sign(header))
+
+    batch_header = batch_pb2.BatchHeader(
+        signer_public_key=batch_key.get_public_key().as_hex(),
+        transaction_ids=[transaction.header_signature]).SerializeToString()
+
+    batch = batch_pb2.Batch(
+        header=batch_header,
+        header_signature=batch_key.sign(batch_header),
+        transactions=[transaction])
+
+    batch_list = batch_pb2.BatchList(
+        batches=[batch])
+    return batch_list, batch.header_signature
+
+
+def make_header_and_batch(payload, inputs, outputs, txn_key, batch_key):
+
+    header = make_header(
+        inputs=inputs,
+        outputs=outputs,
+        payload_sha512=hashlib.sha512(
+            payload.SerializeToString()).hexdigest(),
+        signer_pubkey=txn_key.get_public_key().as_hex(),
+        batcher_pubkey=batch_key.get_public_key().as_hex())
+
+    return wrap_payload_in_txn_batch(
+        txn_key=txn_key,
+        payload=payload.SerializeToString(),
+        header=header.SerializeToString(),
+        batch_key=batch_key)
+
+
+def make_header(inputs,
+                outputs,
+                payload_sha512,
+                signer_pubkey,
+                batcher_pubkey):
+    header = transaction_pb2.TransactionHeader(
+        inputs=inputs,
+        outputs=outputs,
+        batcher_public_key=batcher_pubkey,
+        dependencies=[],
+        family_name=addresser.FAMILY_NAME,
+        family_version='1.0',
+        nonce=uuid4().hex,
+        signer_public_key=signer_pubkey,
+        payload_sha512=payload_sha512)
+    return header

--- a/transaction_creation/marketplace_transaction/transaction_creation.py
+++ b/transaction_creation/marketplace_transaction/transaction_creation.py
@@ -1,0 +1,51 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# -----------------------------------------------------------------------------
+
+from marketplace_addressing import addresser
+
+from marketplace_transaction.common import make_header_and_batch
+from marketplace_transaction.protobuf import payload_pb2
+
+
+def create_account(txn_key, batch_key, label, description):
+    """Create a CreateAccount txn and wrap it in a batch and batchlist.
+
+    Args:
+        txn_key (sawtooth_signing.Signer): The Txn signer key pair.
+        batch_key (sawtooth_signing.Signer): The Batch signer key pair.
+        label (str): The account's label.
+        description (str): The description of the account.
+
+    Returns:
+        tuple: BatchList, signature tuple
+    """
+
+    inputs = [addresser.make_account_address(
+        account_id=txn_key.get_public_key().as_hex())]
+
+    outputs = [addresser.make_account_address(
+        account_id=txn_key.get_public_key().as_hex())]
+
+    account = payload_pb2.CreateAccount(
+        label=label,
+        description=description)
+    payload = payload_pb2.TransactionPayload(create_account=account)
+
+    return make_header_and_batch(
+        payload=payload,
+        inputs=inputs,
+        outputs=outputs,
+        txn_key=txn_key,
+        batch_key=batch_key)


### PR DESCRIPTION
This PR is built off of #12. To test it run `./bin/run_integration_test blockchain`. It adds the functionality to the Transaction Processor to handle a create account transaction.