### PR TITLE
Change docker-compose validator commands to allow restart

### DIFF
--- a/docker-compose-installed.yaml
+++ b/docker-compose-installed.yaml
@@ -103,10 +103,12 @@ services:
       - 4004
     command: |
       bash -c "
+        if [ ! -f /etc/sawtooth/keys/validator.priv ]; then
         sawadm keygen &&
         sawtooth keygen my_key &&
         sawset genesis -k /root/.sawtooth/keys/my_key.priv &&
-        sawadm genesis config-genesis.batch &&
+        sawadm genesis config-genesis.batch
+        fi;
         sawtooth-validator -vv \
           --endpoint tcp://validator:8800 \
           --bind component:tcp://eth0:4004 \

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -123,7 +123,9 @@ services:
       - sawtooth-rest-api
     entrypoint: |
       bash -c "
-        sawtooth keygen &&
+        if [ ! -f /root/.sawtooth/keys/root.priv ]; then
+        sawtooth keygen
+        fi;
         tail -f /dev/null
       "
   settings-tp:
@@ -140,10 +142,12 @@ services:
       - '4040:4004'
     command: |
       bash -c "
+        if [ ! -f /etc/sawtooth/keys/validator.priv ]; then
         sawadm keygen &&
         sawtooth keygen my_key &&
         sawset genesis -k /root/.sawtooth/keys/my_key.priv &&
-        sawadm genesis config-genesis.batch &&
+        sawadm genesis config-genesis.batch
+        fi;
         sawtooth-validator -vv \
           --endpoint tcp://validator:8800 \
           --bind component:tcp://eth0:4004 \


### PR DESCRIPTION
This allows for docker-compose up then ctl^c and docker-compose up again.
The data files don't get destroyed.

Signed-off-by: Boyd Johnson <bjohnson@bitwise.io>