### PR TITLE
Add account detail page

### DIFF
--- a/bin/dev-tools
+++ b/bin/dev-tools
@@ -50,14 +50,10 @@ build_client() {
     info "Building Protobuf modules"
     docker build . -f dev-tools/Dockerfile -t market-dev-env
     docker run --rm \
-        -v $(pwd):/project/sawtooth-marketplace market-dev-env bash -c "\
-            cd sawbuck_app/\
-            && mv /project/sawtooth-marketplace/sawbuck_app/node_modules /project/sawtooth-marketplace/sawbuck_app/node_modules-temp || true\
-            && ln -s /project/sawbuck_app/node_modules /project/sawtooth-marketplace/sawbuck_app/node_modules\
-            && npm run build\
-            && rm /project/sawtooth-marketplace/sawbuck_app/node_modules\
-            && mv /project/sawtooth-marketplace/sawbuck_app/node_modules-temp /project/sawtooth-marketplace/sawbuck_app/node_modules || true\
-        "
+        -v $(pwd):/project/sawtooth-marketplace \
+        -v /project/sawtooth-marketplace/sawbuck_app/node_modules \
+        market-dev-env \
+        bash -c "cd sawbuck_app/ && npm run build"
 }
 
 run_tests() {

--- a/dev-tools/Dockerfile
+++ b/dev-tools/Dockerfile
@@ -44,9 +44,9 @@ RUN pip3 install \
     sanic \
     itsdangerous
 
-COPY sawbuck_app/package.json /project/sawbuck_app/
+COPY sawbuck_app/package.json /project/sawtooth-marketplace/sawbuck_app/
 
-WORKDIR /project/sawbuck_app
+WORKDIR /project/sawtooth-marketplace/sawbuck_app
 
 RUN npm install
 

--- a/integration_tests/rest_api/setup_data_hooks.py
+++ b/integration_tests/rest_api/setup_data_hooks.py
@@ -27,7 +27,9 @@ INVALID_SPEC_IDS = [
 
 ACCOUNT = {
     'email': 'suzie72@suze.au.co',
-    'password': '12345'
+    'password': '12345',
+    'label': 'Susan',
+    'description': 'Susan\'s Account'
 }
 
 

--- a/rest_api/api-spec.yaml
+++ b/rest_api/api-spec.yaml
@@ -96,6 +96,29 @@ paths:
         500:
           $ref: '#/responses/500ServerError'
 
+    patch:
+      description: Updates auth information for the authorized account
+      security:
+        - AuthToken: []
+      parameters:
+        - name: authInfo
+          description: Authorization info to be updated
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/AuthCredentials'
+      responses:
+        200:
+          description: Success response with the updated Account
+          schema:
+            $ref: '#/definitions/AccountObject'
+        400:
+          $ref: '#/responses/400BadRequest'
+        401:
+          $ref: '#/responses/401Unauthorized'
+        500:
+          $ref: '#/responses/500ServerError'
+
   /accounts/{key}:
     parameters:
       - $ref: '#/parameters/AccountKey'

--- a/sawbuck_app/Dockerfile
+++ b/sawbuck_app/Dockerfile
@@ -21,6 +21,7 @@ FROM httpd:2.4
 RUN echo "\
 \n\
 ServerName sawbuck_app\n\
+AddDefaultCharset utf-8\n\
 LoadModule proxy_module modules/mod_proxy.so\n\
 LoadModule proxy_http_module modules/mod_proxy_http.so\n\
 ProxyPass /api http://market-rest-api:8000\n\

--- a/sawbuck_app/Dockerfile-installed
+++ b/sawbuck_app/Dockerfile-installed
@@ -27,6 +27,7 @@ COPY --from=0 /project/sawbuck_app/public/ /usr/local/apache2/htdocs/
 RUN echo "\
 \n\
 ServerName sawbuck_app\n\
+AddDefaultCharset utf-8\n\
 LoadModule proxy_module modules/mod_proxy.so\n\
 LoadModule proxy_http_module modules/mod_proxy_http.so\n\
 ProxyPass /api http://market-rest-api:8000\n\

--- a/sawbuck_app/src/components/layout.js
+++ b/sawbuck_app/src/components/layout.js
@@ -23,7 +23,12 @@ const octicons = require('octicons')
 /**
  * Returns a header styled to be a page title
  */
-const title = title => m('h3.text-center.mb-3', title)
+const title = title => m('h2.text-center.mb-3', title)
+
+/**
+ * Returns a sub-header styled to contain a short description
+ */
+const description = desc => m('h4.text-center.text-muted.mb-3', desc)
 
 /**
  * Returns a row of any number of columns, suitable for placing in a container
@@ -40,6 +45,7 @@ const icon = name => m.trust(octicons[name].toSVG())
 
 module.exports = {
   title,
+  description,
   row,
   icon
 }

--- a/sawbuck_app/src/main.js
+++ b/sawbuck_app/src/main.js
@@ -27,6 +27,7 @@ const navigation = require('./components/navigation')
 
 const LoginForm = require('./views/login_form')
 const SignupForm = require('./views/signup_form')
+const AccountDetailPage = require('./views/account_detail')
 
 /**
  * A basic layout component that adds the navbar to the view.
@@ -95,11 +96,22 @@ const logout = () => {
 }
 
 /**
+ * Redirects to user's personal account page if logged in.
+ */
+const userAccount = () => {
+  const publicKey = api.getPublicKey()
+  if (publicKey) m.route.set(`/accounts/${publicKey}`)
+  else m.route.set('/')
+}
+
+/**
  * Build and mount app/router
  */
 document.addEventListener('DOMContentLoaded', () => {
   m.route(document.querySelector('#app'), '/', {
     '/': resolve(LoginForm),
+    '/account': { onmatch: userAccount },
+    '/accounts/:publicKey': resolve(AccountDetailPage),
     '/login': resolve(LoginForm),
     '/logout': { onmatch: logout },
     '/signup': resolve(SignupForm)

--- a/sawbuck_app/src/services/api.js
+++ b/sawbuck_app/src/services/api.js
@@ -54,7 +54,7 @@ const getPublicKey = () => {
   if (!token) return null
 
   const content = window.atob(token.split('.')[1])
-  return JSON.parse(content)['public_key']
+  return JSON.parse(content).public_key
 }
 
 // Adds Authorization header and prepends API path to url

--- a/sawbuck_app/src/views/account_detail.js
+++ b/sawbuck_app/src/views/account_detail.js
@@ -97,6 +97,17 @@ const passwordField = state => {
       infoForm(state, 'password', onSubmit, { type: 'password' })))
 }
 
+const holdingRow = holding => {
+  return [
+    m('.row',
+      m('.col-md-8', holding.label),
+      m('.col-md-2', holding.quantity),
+      m('.col-md-2', holding.asset)),
+    m('.row.mb-3',
+      m('.col-md.text-muted', holding.description))
+  ]
+}
+
 /**
  * Displays information for a particular Account.
  * The information can be edited if the user themself.
@@ -111,6 +122,7 @@ const AccountDetailPage = {
 
   view (vnode) {
     const publicKey = _.get(vnode.state, 'account.publicKey', '')
+    const holdings = _.get(vnode.state, 'account.holdings', [])
 
     const profileContent = layout.row([
       editField(vnode.state, 'Email', 'email'),
@@ -122,7 +134,12 @@ const AccountDetailPage = {
       layout.description(_.get(vnode.state, 'account.description', '')),
       m('.container',
         publicKey === api.getPublicKey() ? profileContent : null,
-        layout.row(staticField('Public Key', publicKey)))
+        layout.row(staticField('Public Key', publicKey)),
+        layout.row(staticField(
+          'Holdings',
+          holdings.length > 0
+            ? holdings.map(holdingRow)
+            : m('em', 'this account currently has no holdings'))))
     ]
   }
 }

--- a/sawbuck_app/src/views/account_detail.js
+++ b/sawbuck_app/src/views/account_detail.js
@@ -98,14 +98,19 @@ const passwordField = state => {
 }
 
 const holdingRow = holding => {
-  return [
-    m('.row',
-      m('.col-md-8', holding.label),
-      m('.col-md-2', holding.quantity),
-      m('.col-md-2', holding.asset)),
-    m('.row.mb-3',
-      m('.col-md.text-muted', holding.description))
-  ]
+  return m('.row.mt-3', [
+    m('.col-md-7',
+      layout.row(m('h6', holding.label)),
+      layout.row(m('.text-muted', holding.description))),
+    m('.col-md-5',
+      m('.card.mr-3.border-success', [
+        m('.card-header.text-success.border-success.text-center',
+          {style: 'line-height:0.8;'},
+          holding.asset),
+        m('.card-body', {style: 'line-height:0.2;'},
+          m('p.card-text.text-right', m('em', holding.quantity)))
+      ]))
+  ])
 }
 
 /**

--- a/sawbuck_app/src/views/account_detail.js
+++ b/sawbuck_app/src/views/account_detail.js
@@ -1,0 +1,130 @@
+/**
+ * Copyright 2017 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ----------------------------------------------------------------------------
+ */
+'use strict'
+
+const m = require('mithril')
+const _ = require('lodash')
+
+const api = require('../services/api')
+const layout = require('../components/layout')
+const forms = require('../components/forms')
+
+// Returns a string of bullets
+const bullets = count => _.fill(Array(count), '•').join('')
+
+// Basis for info fields with headers
+const labeledField = (header, field) => {
+  return m('.field-group.mt-5', header, field)
+}
+
+const fieldHeader = (label, ...additions) => {
+  return m('.field-header', [
+    m('span.h5.mr-3', label),
+    additions
+  ])
+}
+
+// Simple info field with a label
+const staticField = (label, info) => labeledField(fieldHeader(label), info)
+
+const toggledInfo = (isToggled, initialView, toggledView) => {
+  return m('.field-info', isToggled ? toggledView : initialView)
+}
+
+// An in-line form for updating a single field
+const infoForm = (state, key, onSubmit, opts) => {
+  return m('form.form-inline', {
+    onsubmit: () => onSubmit().then(() => { state.toggled[key] = false })
+  }, [
+    m('input.form-control-sm.mr-1', _.assign({
+      oninput: m.withAttr('value', value => { state.update[key] = value })
+    }, opts)),
+    m('button.btn.btn-secondary.btn-sm.mr-1', {
+      onclick: () => { state.toggled[key] = false }
+    }, 'Cancel'),
+    m('button.btn.btn-primary.btn-sm.mr-1', { type: 'submit' }, 'Update')
+  ])
+}
+
+// Pencil icon that simply toggles visibility
+const editIcon = (obj, key) => {
+  return forms.clickIcon('pencil', () => { obj[key] = !obj[key] })
+}
+
+// Edits a field in state
+const editField = (state, label, key) => {
+  const currentInfo = _.get(state, ['account', key], '')
+  const onSubmit = () => {
+    return api.patch('accounts', _.pick(state.update, key))
+      .then(() => { state.account[key] = state.update[key] })
+  }
+
+  return labeledField(
+    fieldHeader(label, editIcon(state.toggled, key)),
+    toggledInfo(
+      state.toggled[key],
+      currentInfo,
+      infoForm(state, key, onSubmit, {placeholder: currentInfo})))
+}
+
+const passwordField = state => {
+  const onSubmit = () => {
+    return api.patch('accounts', {
+      password: state.update.password
+    })
+      .then(() => m.redraw())
+  }
+
+  return labeledField(
+    fieldHeader('Password', editIcon(state.toggled, 'password')),
+    toggledInfo(
+      state.toggled.password,
+      bullets(16),
+      infoForm(state, 'password', onSubmit, { type: 'password' })))
+}
+
+/**
+ * Displays information for a particular Account.
+ * The information can be edited if the user themself.
+ */
+const AccountDetailPage = {
+  oninit (vnode) {
+    vnode.state.toggled = {}
+    vnode.state.update = {}
+    api.get(`accounts/${vnode.attrs.publicKey}`)
+      .then(account => { vnode.state.account = account })
+  },
+
+  view (vnode) {
+    const publicKey = _.get(vnode.state, 'account.publicKey', '')
+
+    const profileContent = layout.row([
+      editField(vnode.state, 'Email', 'email'),
+      passwordField(vnode.state)
+    ])
+
+    return [
+      layout.title(_.get(vnode.state, 'account.label', '')),
+      layout.description(_.get(vnode.state, 'account.description', '')),
+      m('.container',
+        publicKey === api.getPublicKey() ? profileContent : null,
+        layout.row(staticField('Public Key', publicKey)))
+    ]
+  }
+}
+
+module.exports = AccountDetailPage


### PR DESCRIPTION
Adds an account detail page to the client which logged-in users can view for their own account.

Includes a number of other updates to help enable this page. Test with `docker-compose up`, and then navigating to `http://localhost:8041`. Signup and then click on the `Account` button in the navbar.

_Screenshot:_
![screen shot 2017-12-08 at 11 10 03 am](https://user-images.githubusercontent.com/8889580/33776973-b50c3a7c-dc08-11e7-9574-666898ee93c9.png)
_*Shown with placeholder data not included in PR_
