### PR TITLE
Add Asset List Page

### DIFF
--- a/sawbuck_app/src/main.js
+++ b/sawbuck_app/src/main.js
@@ -25,9 +25,10 @@ const m = require('mithril')
 const api = require('./services/api')
 const navigation = require('./components/navigation')
 
+const AccountDetailPage = require('./views/account_detail')
+const AssetListPage = require('./views/asset_list')
 const LoginForm = require('./views/login_form')
 const SignupForm = require('./views/signup_form')
-const AccountDetailPage = require('./views/account_detail')
 
 /**
  * A basic layout component that adds the navbar to the view.
@@ -112,6 +113,7 @@ document.addEventListener('DOMContentLoaded', () => {
     '/': resolve(LoginForm),
     '/account': { onmatch: userAccount },
     '/accounts/:publicKey': resolve(AccountDetailPage),
+    '/assets': resolve(AssetListPage),
     '/login': resolve(LoginForm),
     '/logout': { onmatch: logout },
     '/signup': resolve(SignupForm)

--- a/sawbuck_app/src/views/asset_list.js
+++ b/sawbuck_app/src/views/asset_list.js
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2017 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ----------------------------------------------------------------------------
+ */
+'use strict'
+
+const _ = require('lodash')
+
+const layout = require('../components/layout')
+const api = require('../services/api')
+
+/**
+ * A page displaying each Asset, with links to create an Offer,
+ * or to view more detail.
+ */
+const AssetListPage = {
+  oninit (vnode) {
+    api.get(`assets`)
+      .then(assets => { vnode.state.assets = assets })
+  },
+
+  view (vnode) {
+    const assets = _.get(vnode.state, 'assets', [])
+
+    return [
+      layout.title('Assets Available'),
+      layout.row(JSON.stringify(assets))
+    ]
+  }
+}
+
+module.exports = AssetListPage

--- a/sawbuck_app/src/views/asset_list.js
+++ b/sawbuck_app/src/views/asset_list.js
@@ -16,10 +16,35 @@
  */
 'use strict'
 
+const m = require('mithril')
 const _ = require('lodash')
 
 const layout = require('../components/layout')
 const api = require('../services/api')
+
+const offerButton = (name, key = 'source') => {
+  const label = key === 'target' ? 'Request' : 'Offer'
+  const onclick = () => console.log(`Offering ${name} as ${key}...`)
+
+  return m('button.btn.btn-outline-primary.mr-3', { onclick }, label)
+}
+
+const assetRow = asset => {
+  const safeName = window.encodeURI(asset.name)
+  return m('.row.mb-5', [
+    m('.col-md-8', [
+      layout.row(m('a.h5', {
+        href: `/assets/${safeName}`,
+        oncreate: m.route.link
+      }, asset.name)),
+      layout.row(m('.text-muted', asset.description))
+    ]),
+    m('.col-md-4.mt-3', [
+      offerButton(asset.name),
+      offerButton(asset.name, 'target')
+    ])
+  ])
+}
 
 /**
  * A page displaying each Asset, with links to create an Offer,
@@ -36,7 +61,11 @@ const AssetListPage = {
 
     return [
       layout.title('Assets Available'),
-      layout.row(JSON.stringify(assets))
+      m('.container.mt-6',
+        assets.length > 0
+          ? assets.map(assetRow)
+          : m('.text-center',
+              m('em', 'there are currently no available assets')))
     ]
   }
 }


### PR DESCRIPTION
Lists assets with buttons to create offers based on them. Buttons will eventually create a modal, currently just log to the console. Tough to test until `GET /assets` is implemented (and even then there will be no test data). Should work fine once those pieces are brought online.

Screenshot:
![screen shot 2017-12-07 at 5 28 25 pm](https://user-images.githubusercontent.com/8889580/33744033-e298afc8-db74-11e7-83d9-600f95bc981f.png)
_*Pictured with placeholder data not included in PR_