### PR TITLE
Fix missing reference in Api Spec

### DIFF
--- a/rest_api/api-spec.yaml
+++ b/rest_api/api-spec.yaml
@@ -111,7 +111,7 @@ paths:
         200:
           description: Success response with the updated Account
           schema:
-            $ref: '#/definitions/AccountObject'
+            $ref: '#/definitions/AuthorizedAccountObject'
         400:
           $ref: '#/responses/400BadRequest'
         401:


### PR DESCRIPTION
Signed-off-by: Boyd Johnson <bjohnson@bitwise.io>

With this fix we have 4 passing Dredd tests. Without it the Swagger yaml can't be parsed.