### PR TITLE
Add Asset Detail page to the Sawbuck Manager

### DIFF
--- a/sawbuck_app/src/components/layout.js
+++ b/sawbuck_app/src/components/layout.js
@@ -39,6 +39,32 @@ const row = columns => {
 }
 
 /**
+ * Divides columns into a series of rows with a number of columns per row
+ */
+const sectionedRows = (columns, count = 2) => {
+  return columns
+    .reduce((pairs, col) => {
+      if (_.last(pairs).length < 2) _.last(pairs).push(col)
+      if (_.last(pairs).length === 2) pairs.push([])
+      return pairs
+    }, [[]])
+    .map(pair => {
+      if (pair.length === 0) return null
+      return row(pair)
+    })
+}
+
+/**
+ * Returns a sub-header followed by related info
+ */
+const labeledField = (label, info) => {
+  return m('.labeled-field.mt-5', [
+    m('h5', label),
+    info
+  ])
+}
+
+/**
  * Returns a mithriled icon from Github's octicon set
  */
 const icon = name => m.trust(octicons[name].toSVG())
@@ -47,5 +73,7 @@ module.exports = {
   title,
   description,
   row,
+  sectionedRows,
+  labeledField,
   icon
 }

--- a/sawbuck_app/src/main.js
+++ b/sawbuck_app/src/main.js
@@ -26,6 +26,7 @@ const api = require('./services/api')
 const navigation = require('./components/navigation')
 
 const AccountDetailPage = require('./views/account_detail')
+const AssetDetailPage = require('./views/asset_detail')
 const AssetListPage = require('./views/asset_list')
 const LoginForm = require('./views/login_form')
 const SignupForm = require('./views/signup_form')
@@ -114,6 +115,7 @@ document.addEventListener('DOMContentLoaded', () => {
     '/account': { onmatch: userAccount },
     '/accounts/:publicKey': resolve(AccountDetailPage),
     '/assets': resolve(AssetListPage),
+    '/assets/:name': resolve(AssetDetailPage),
     '/login': resolve(LoginForm),
     '/logout': { onmatch: logout },
     '/signup': resolve(SignupForm)

--- a/sawbuck_app/src/views/asset_detail.js
+++ b/sawbuck_app/src/views/asset_detail.js
@@ -1,0 +1,81 @@
+/**
+ * Copyright 2017 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ----------------------------------------------------------------------------
+ */
+'use strict'
+
+const m = require('mithril')
+const _ = require('lodash')
+
+const api = require('../services/api')
+const layout = require('../components/layout')
+
+const ruleSection = ({ type, value }) => {
+  return m('.rule-section', [
+    m('span.text-success', layout.icon('check'), ' '),
+    type,
+    value ? m('span.text-muted', ' : ', value) : null
+  ])
+}
+
+const offerButton = (name, key = 'source') => {
+  const label = key === 'target' ? 'Request' : 'Offer'
+  const onclick = () => console.log(`Offering ${name} as ${key}...`)
+
+  return m('button.btn-lg.btn-outline-primary', { onclick }, label)
+}
+
+/**
+ * Displays information for a particular Account.
+ * The information can be edited if the user themself.
+ */
+const AssetDetailPage = {
+  oninit (vnode) {
+    const safeName = window.encodeURI(vnode.attrs.name)
+    api.get(`assets/${safeName}`)
+      .then(asset => {
+        vnode.state.asset = asset
+        if (asset.owners.length > 0) {
+          return api.get(`accounts/${asset.owners[0]}`)
+        }
+      })
+      .then(owner => { if (owner) vnode.state.owner = owner })
+  },
+
+  view (vnode) {
+    const rules = _.get(vnode.state, 'asset.rules', [])
+    const name = _.get(vnode.state, 'asset.name', '')
+    const ownerName = _.get(vnode.state, 'owner.label',
+                            _.get(vnode.state, 'owner.public_key',
+                                  ''))
+
+    return [
+      layout.title(name),
+      layout.description(_.get(vnode.state, 'asset.description', '')),
+      m('.container',
+        layout.row(layout.labeledField('Administered by', ownerName)),
+        layout.row(layout.labeledField(
+          'Rules',
+          rules.length > 0
+            ? layout.sectionedRows(rules.map(ruleSection))
+            : m('em', 'this asset has no special rules'))),
+        m('.row.text-center.mt-5',
+          m('.col-md.m-3', offerButton(name)),
+          m('.col-md.m-3', offerButton(name, 'target'))))
+    ]
+  }
+}
+
+module.exports = AssetDetailPage


### PR DESCRIPTION
Adds an Asset Detail page. The styling for Rules may change once they are more hashed out and better implemented. How they are displayed will likely change on a rule-by-rule basis. The Offer/Request buttons are not currently hooked up to anything other than a console log.

Screenshot:
![screen shot 2017-12-08 at 2 38 16 pm](https://user-images.githubusercontent.com/8889580/33784971-9e6a1580-dc28-11e7-9a0d-f510d7f8e74b.png)
_*Shown with placeholder data not included in PR_