### PR TITLE
Implement API accept and close Offers

### DIFF
--- a/integration_tests/rest_api/setup_data_hooks.py
+++ b/integration_tests/rest_api/setup_data_hooks.py
@@ -55,6 +55,11 @@ ASSET = {
     ]
 }
 
+ASSET_2 = {
+    'name': 'Imperial Credit',
+    'description': 'Standard form of currency throughout the Galactic Empire'
+}
+
 HOLDING = {
     "label": "Suzebucket",
     "description": "The source for all Suzebucks.",
@@ -70,6 +75,17 @@ HOLDING_2 = {
     "quantity": 1337
 }
 
+HOLDING_3 = {
+    "label": "Credit chip 0",
+    "asset": "Imperial Credit",
+    "quantity": 3000
+}
+
+HOLDING_4 = {
+    "label": "Credit chip 1",
+    "asset": "Imperial Credit",
+    "quantity": 3000
+}
 
 AUTH_ACCOUNT = {
     'email': 'qwerty@suze.au.co',
@@ -152,10 +168,13 @@ def initialize_sample_resources(txns):
 
     # Create ASSET
     seeded_data['asset'] = submit('assets', ASSET)
+    seeded_data['asset_2'] = submit('assets', ASSET_2)
 
     # Create HOLDINGS
     seeded_data['holding'] = submit('holdings', HOLDING)
     seeded_data['holding_2'] = submit('holdings', HOLDING_2)
+    seeded_data['holding_3'] = submit('holdings', HOLDING_3)
+    seeded_data['holding_4'] = submit('holdings', HOLDING_4)
 
     # Create AUTH_ACCOUNT
     auth_account_response = submit('accounts', AUTH_ACCOUNT)
@@ -164,7 +183,7 @@ def initialize_sample_resources(txns):
 
     # Create OFFER
     OFFER['source'] = seeded_data['holding']['id']
-    OFFER['target'] = seeded_data['holding_2']['id']
+    OFFER['target'] = seeded_data['holding_3']['id']
     seeded_data['offer'] = submit('offers', OFFER)
 
     # Replace example auth and identifiers with ones from seeded data
@@ -179,8 +198,16 @@ def initialize_sample_resources(txns):
 def add_holding(txn):
     patch_body(txn, {
             'source': seeded_data['holding']['id'],
-            'target': seeded_data['holding']['id'],
+            'target': seeded_data['holding_3']['id'],
             'targetQuantity': 1337
+        })
+
+@hooks.before('/offers/{id}/accept > PATCH > 200 > application/json')
+def add_accept_info(txn):
+    patch_body(txn, {
+            'source': seeded_data['holding_4']['id'],
+            'count': 1,
+            'target': seeded_data['holding_2']['id']
         })
 
 

--- a/rest_api/api-spec.yaml
+++ b/rest_api/api-spec.yaml
@@ -673,14 +673,14 @@ definitions:
     type: object
     required:
       - source
-      - sourceQuantity
+      - count
       - target
     properties:
       source:
         description: The id of a Holding from which resources will be drawn
         type: string
         example: 0ab3febf-e7a3-4b90-966a-68e2f273c7a5
-      sourceQuantity:
+      count:
         description: The number of resources to send out during exchange
         type: integer
         example: 1000

--- a/rest_api/db/accounts_query.py
+++ b/rest_api/db/accounts_query.py
@@ -18,17 +18,18 @@ from rethinkdb.errors import ReqlNonExistenceError
 
 from api.errors import ApiBadRequest
 
-from db import blocks_query
+from db.common import fetch_holdings
+from db.common import fetch_latest_block_num
 
 
 async def fetch_all_account_resources(conn):
     return await r.table('accounts')\
-        .filter((blocks_query.latest_block_num() >= r.row['start_block_num'])
-                & (blocks_query.latest_block_num() < r.row['end_block_num']))\
+        .filter((fetch_latest_block_num() >= r.row['start_block_num'])
+                & (fetch_latest_block_num() < r.row['end_block_num']))\
         .map(lambda account: account.merge(
             {'publicKey': account['public_key']}))\
         .map(lambda account: account.merge(
-            {'holdings': _fetch_holdings(account['holdings'])}))\
+            {'holdings': fetch_holdings(account['holdings'])}))\
         .map(lambda account: (account['label'] == "").branch(
             account.without('label'), account))\
         .map(lambda account: (account['description'] == "").branch(
@@ -44,7 +45,7 @@ async def fetch_account_resource(conn, public_key, auth_key):
             .get_all(public_key, index='public_key')\
             .max('start_block_num')\
             .merge({'publicKey': r.row['public_key']})\
-            .merge({'holdings': _fetch_holdings(r.row['holdings'])})\
+            .merge({'holdings': fetch_holdings(r.row['holdings'])})\
             .do(lambda account: (r.expr(auth_key).eq(public_key)).branch(
                 account.merge(_fetch_email(public_key)), account))\
             .do(lambda account: (account['label'] == "").branch(
@@ -64,10 +65,3 @@ def _fetch_email(public_key):
         .get_all(public_key, index='public_key')\
         .pluck('email')\
         .coerce_to('array')[0]
-
-
-def _fetch_holdings(holding_ids):
-    return r.table('holdings')\
-        .get_all(r.args(holding_ids), index='id')\
-        .without('start_block_num', 'end_block_num', 'delta_id', 'account')\
-        .coerce_to('array')

--- a/rest_api/db/assets_query.py
+++ b/rest_api/db/assets_query.py
@@ -18,13 +18,13 @@ from rethinkdb.errors import ReqlNonExistenceError
 
 from api.errors import ApiBadRequest
 
-from db import blocks_query
+from db.common import fetch_latest_block_num
 
 
 async def fetch_all_asset_resources(conn):
     return await r.table('assets')\
-        .filter((blocks_query.latest_block_num() >= r.row['start_block_num'])
-                & (blocks_query.latest_block_num() < r.row['end_block_num']))\
+        .filter((fetch_latest_block_num() >= r.row['start_block_num'])
+                & (fetch_latest_block_num() < r.row['end_block_num']))\
         .map(lambda asset: (asset['description'] == "").branch(
             asset.without('description'), asset))\
         .map(lambda asset: (asset['rules'] == []).branch(

--- a/rest_api/db/common.py
+++ b/rest_api/db/common.py
@@ -19,10 +19,17 @@ from rethinkdb import ReqlNonExistenceError
 from api.errors import ApiInternalError
 
 
-def latest_block_num():
+def fetch_latest_block_num():
     try:
         return r.table('blocks')\
             .max(index='block_num')\
             .get_field('block_num')
     except ReqlNonExistenceError:
         raise ApiInternalError('No block data found in state')
+
+
+def fetch_holdings(holding_ids):
+    return r.table('holdings')\
+        .get_all(r.args(holding_ids), index='id')\
+        .without('start_block_num', 'end_block_num', 'delta_id', 'account')\
+        .coerce_to('array')

--- a/rest_api/db/offers_query.py
+++ b/rest_api/db/offers_query.py
@@ -18,13 +18,13 @@ from rethinkdb.errors import ReqlNonExistenceError
 
 from api.errors import ApiBadRequest
 
-from db import blocks_query
+from db.common import fetch_latest_block_num
 
 
 async def fetch_all_offer_resources(conn, query_params):
     return await r.table('offers')\
-        .filter((blocks_query.latest_block_num() >= r.row['start_block_num'])
-                & (blocks_query.latest_block_num() < r.row['end_block_num']))\
+        .filter((fetch_latest_block_num() >= r.row['start_block_num'])
+                & (fetch_latest_block_num() < r.row['end_block_num']))\
         .filter(query_params)\
         .map(lambda offer: (offer['label'] == "").branch(
             offer.without('label'), offer))\

--- a/transaction_creation/marketplace_transaction/transaction_creation.py
+++ b/transaction_creation/marketplace_transaction/transaction_creation.py
@@ -225,16 +225,20 @@ def accept_offer(txn_key,
         tuple: List of Batch, signature tuple
     """
 
-    inputs = [addresser.make_holding_address(receiver_source),
-              addresser.make_holding_address(receiver_target),
+    inputs = [addresser.make_holding_address(receiver_target),
               addresser.make_holding_address(offerer_source),
-              addresser.make_holding_address(offerer_target),
               addresser.make_offer_address(identifier)]
 
-    outputs = [addresser.make_holding_address(receiver_source),
-               addresser.make_holding_address(receiver_target),
-               addresser.make_holding_address(offerer_source),
-               addresser.make_holding_address(offerer_target)]
+    outputs = [addresser.make_holding_address(receiver_target),
+               addresser.make_holding_address(offerer_source)]
+
+    if receiver_source is not None:
+        inputs.append(addresser.make_holding_address(receiver_source))
+        outputs.append(addresser.make_holding_address(receiver_source))
+
+    if offerer_target is not None:
+        inputs.append(addresser.make_holding_address(offerer_target))
+        outputs.append(addresser.make_holding_address(offerer_target))
 
     accept_txn = payload_pb2.AcceptOffer(
         id=identifier,


### PR DESCRIPTION
This PR adds functionality for the `POST /offers/<offer_id>/accept` and `POST /offers/<offer_id>/close` routes.

To test the API responses without TP functionality, comment out lines 109-114 and 141-146 in `offers.py`.