### PR TITLE
Add Create Offer Modal

### DIFF
--- a/sawbuck_app/src/components/layout.js
+++ b/sawbuck_app/src/components/layout.js
@@ -43,10 +43,10 @@ const row = columns => {
  */
 const sectionedRows = (columns, count = 2) => {
   return columns
-    .reduce((pairs, col) => {
-      if (_.last(pairs).length < 2) _.last(pairs).push(col)
-      if (_.last(pairs).length === 2) pairs.push([])
-      return pairs
+    .reduce((groups, col) => {
+      if (_.last(groups).length < count) _.last(groups).push(col)
+      if (_.last(groups).length === count) groups.push([])
+      return groups
     }, [[]])
     .map(pair => {
       if (pair.length === 0) return null

--- a/sawbuck_app/src/components/modals.js
+++ b/sawbuck_app/src/components/modals.js
@@ -21,6 +21,60 @@ const _ = require('lodash')
 const $ = require('jquery')
 
 /**
+ * The surrounding div for a Bootstrap modal
+ */
+const base = (header, body, footer) => {
+  return m('.modal.fade#modal', {
+    tabindex: '-1',
+    role: 'dialog',
+    'aria-labelby': 'modal'
+  }, [
+    m('.modal-dialog', { role: 'document' },
+      m('form',
+        m('.modal-content',
+          header,
+          body,
+          footer)))
+  ])
+}
+
+/**
+ * The header div for a Bootstrap modal, including X to close
+ */
+const header = (title, cancelFn) => {
+  return m('.modal-header', [
+    m('h5.modal-title', title),
+    m('button.close', {
+      type: 'button',
+      onclick: cancelFn,
+      'data-dismiss': 'modal',
+      'aria-label': 'Close'
+    }, m('span', { 'aria-hidden': 'true' }, m.trust('&times;')))
+  ])
+}
+
+/**
+ * The body div for a Bootstrap modal
+ */
+const body = content => m('.modal-body', content)
+
+/**
+ * The footer div for a Bootstrap modal, takes any number of buttons
+ */
+const footer = (...buttons) => m('.modal-footer', buttons)
+
+/**
+ * A button which will dismiss a Bootstrap modal
+ */
+const button = (label, onclick, color = 'primary') => {
+ return m(`button.btn.btn-${color}`, {
+    type: 'button',
+    onclick,
+    'data-dismiss': 'modal'
+  }, label)
+}
+
+/**
  * A basic Bootstrap modal. Requires at least a title and body be set in
  * attributes. Also accepts text and functions for accepting/canceling.
  */
@@ -32,36 +86,12 @@ const BasicModal = {
     const acceptFn = vnode.attrs.acceptFn || _.identity
     const cancelFn = vnode.attrs.cancelFn || _.identity
 
-    return m('.modal.fade#modal', {
-      tabindex: '-1',
-      role: 'dialog',
-      'aria-labelby': 'modal'
-    }, [
-      m('.modal-dialog', { role: 'document' },
-        m('form',
-          m('.modal-content',
-            m('.modal-header',
-              m('h5.modal-title', vnode.attrs.title),
-              m('button.close', {
-                type: 'button',
-                onclick: cancelFn,
-                'data-dismiss': 'modal',
-                'aria-label': 'Close'
-              }, m('span', { 'aria-hidden': 'true' }, m.trust('&times;')))
-              ),
-            m('.modal-body', vnode.attrs.body),
-            m('.modal-footer',
-              m('button.btn.btn-secondary', {
-                type: 'button',
-                onclick: cancelFn,
-                'data-dismiss': 'modal'
-              }, cancelText),
-              m('button.btn.btn-primary', {
-                type: 'submit',
-                onclick: acceptFn,
-                'data-dismiss': 'modal'
-              }, acceptText)))))
-    ])
+    return base(
+      header(vnode.attrs.title, cancelFn),
+      body(vnode.attrs.body),
+      footer(
+        button(cancelText, cancelFn, 'secondary'),
+        button(acceptText, acceptFn)))
   }
 }
 
@@ -89,6 +119,11 @@ const show = (modal, attrs, children) => {
 }
 
 module.exports = {
+  base,
+  header,
+  body,
+  footer,
+  button,
   BasicModal,
   show
 }

--- a/sawbuck_app/src/components/modals.js
+++ b/sawbuck_app/src/components/modals.js
@@ -109,8 +109,11 @@ const show = (modal, attrs, children) => {
   })
 
   const container = document.getElementById('modal-container')
-  m.render(container,
-           m(modal, _.assign(attrs, { acceptFn, cancelFn }, children)))
+  m.mount(container, {
+    view () {
+      return m(modal, _.assign(attrs, { acceptFn, cancelFn }, children))
+    }
+  })
   const $modal = $('#modal')
   $modal.on('hidden.bs.modal', () => m.mount(container, null))
   $modal.modal('show')

--- a/sawbuck_app/src/components/modals.js
+++ b/sawbuck_app/src/components/modals.js
@@ -66,12 +66,12 @@ const footer = (...buttons) => m('.modal-footer', buttons)
 /**
  * A button which will dismiss a Bootstrap modal
  */
-const button = (label, onclick, color = 'primary') => {
- return m(`button.btn.btn-${color}`, {
+const button = (label, onclick, color = 'primary', attrs = {}) => {
+  return m(`button.btn.btn-${color}`, _.assign({
     type: 'button',
     onclick,
     'data-dismiss': 'modal'
-  }, label)
+  }, attrs), label)
 }
 
 /**

--- a/sawbuck_app/src/views/asset_detail.js
+++ b/sawbuck_app/src/views/asset_detail.js
@@ -22,10 +22,13 @@ const _ = require('lodash')
 const api = require('../services/api')
 const layout = require('../components/layout')
 const mkt = require('../components/marketplace')
+const { createOffer } = require('./create_offer_modal')
 
 const offerButton = (name, key = 'source') => {
   const label = key === 'target' ? 'Request' : 'Offer'
-  const onclick = () => console.log(`Offering ${name} as ${key}...`)
+  const onclick = key === 'target'
+    ? () => createOffer(null, name)
+    : () => createOffer(name)
 
   return m('button.btn-lg.btn-outline-primary', { onclick }, label)
 }

--- a/sawbuck_app/src/views/asset_list.js
+++ b/sawbuck_app/src/views/asset_list.js
@@ -21,10 +21,13 @@ const _ = require('lodash')
 
 const layout = require('../components/layout')
 const api = require('../services/api')
+const { createOffer } = require('./create_offer_modal')
 
 const offerButton = (name, key = 'source') => {
   const label = key === 'target' ? 'Request' : 'Offer'
-  const onclick = () => console.log(`Offering ${name} as ${key}...`)
+  const onclick = key === 'target'
+    ? () => createOffer(null, name)
+    : () => createOffer(name)
 
   return m('button.btn.btn-outline-primary.mr-3', { onclick }, label)
 }

--- a/sawbuck_app/src/views/create_offer_modal.js
+++ b/sawbuck_app/src/views/create_offer_modal.js
@@ -1,0 +1,252 @@
+/**
+ * Copyright 2017 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ----------------------------------------------------------------------------
+ */
+'use strict'
+
+const m = require('mithril')
+const _ = require('lodash')
+
+const api = require('../services/api')
+const forms = require('../components/forms')
+const layout = require('../components/layout')
+const mkt = require('../components/marketplace')
+const modals = require('../components/modals')
+
+// Returns a label string, truncated if necessary
+const getLabel = (value, defaultValue, max = 11) => {
+  const label = value || defaultValue
+  if (label.length <= max) return label
+  return `${label.slice(0, max - 3)}...`
+}
+
+// Returns a green check mark if visible
+const check = (isVisible = true) => {
+  return m(`span.text-${isVisible ? 'success' : 'white'}`,
+           layout.icon('check'),
+           ' ')
+}
+
+// Filters holdings by asset if set, sorting otherwise
+const getHoldings = (holdings, asset = null) => {
+  if (asset) {
+    return holdings.filter(holding => holding.asset === asset)
+  }
+  return _.sortBy(holdings, ['asset', 'label'])
+}
+
+// Returns a functon which sets id and label keys for source
+const sourceSetter = (state, key = 'source') => (id, asset) => () => {
+  state.offer[key] = id
+  state[`${key}Label`] = asset
+}
+
+// Returns a function which sets id, label, and additional keys for target
+const targetSetter = state => (id, asset, isFree, isNew) => () => {
+  sourceSetter(state, 'target')(id, asset)()
+  state.noTarget = isFree
+  state.hasNewHolding = isNew
+}
+
+// Gets a list of option objects, with text and an onclick function
+const getOptions = (holdings, state, key = 'source') => {
+  const setter = key !== 'target' ? sourceSetter(state) : targetSetter(state)
+
+  return holdings.map(holding => ({
+    text: [
+      check(state.offer[key] === holding.id),
+      `${holding.asset} (${holding.label || holding.id})`
+    ],
+    onclick: setter(holding.id, holding.asset)
+  }))
+}
+
+// Returns two additional options, free and new holding
+const optionsTail = state => {
+  return [{
+    text: [check(state.noTarget === true), m('em', 'free (No Holding)')],
+    onclick: targetSetter(state)(null, 'free', true)
+  }, {
+    text: [check(state.hasNewHolding === true), m('em', 'New Holding')],
+    onclick: targetSetter(state)(null, 'New Holding', false, true)
+  }]
+}
+
+// A small dropdown for selecting an asset for a new holding
+const assetDropdown = (label, assets, onValue) => {
+  return m('span.dropdown.ml-3', [
+    m('button.btn.btn-success.btn-sm.dropdown-toggle.mb-1', {
+      type: 'button',
+      'data-toggle': 'dropdown',
+      'aria-haspopup': 'true',
+      'aria-expanded': 'false'
+    }, label || 'Asset'),
+    m('.dropdown-menu',
+      assets.map(asset => {
+        return m('button.dropdown-item', {
+          type: 'button',
+          onclick: () => onValue(asset.name)
+        }, check(label === asset.name), asset.name)
+      }))
+  ])
+}
+
+// Small fields with placeholders rather than headers, for new holdings
+const holdingField = (placeholder, onValue) => {
+  return forms.field(onValue, { placeholder, required: false })
+}
+
+// Returns true or false depending on whether or not the form is valid
+const isFormValid = state => {
+  if (!state.offer.source) return false
+  if (!state.offer.sourceQuantity) return false
+  if (state.noTarget) return true
+
+  if (!state.offer.targetQuantity) return false
+  if (state.hasNewHolding && !state.holding.asset) return false
+  if (!state.hasNewHolding && !state.offer.target) return false
+
+  return true
+}
+
+// Returns a function which will submit a new offer, and holding if applicable
+const submitter = (state, onDone) => () => {
+  return Promise.resolve()
+    .then(() => {
+      if (state.hasNewHolding) {
+        const holdingKeys = ['label', 'description', 'asset']
+        return api.post('holdings', _.pick(state.holding, holdingKeys))
+      }
+    })
+    .then(holding => {
+      const offerKeys = [
+        'label', 'description', 'source', 'sourceQuantity',
+        'target', 'targetQuantity', 'rules'
+      ]
+      const offer = _.pick(state.offer, offerKeys)
+      if (holding) offer.target = holding.id
+      return api.post('offers', offer)
+    })
+    .then(onDone)
+    .then(() => m.route.set('/'))
+}
+
+// A versatile modal allowing users to create new offers (and new holdings)
+const CreateOfferModal = {
+  oninit (vnode) {
+    const publicKey = api.getPublicKey()
+    vnode.state.offer = {}
+    vnode.state.holding = {}
+    vnode.state.hasNewHolding = false
+
+    return Promise.all([
+      api.get(`accounts/${publicKey}`),
+      vnode.attrs.target ? null : api.get('assets')
+    ])
+      .then(([ account, assets ]) => {
+        if (assets && assets.error) return console.error(account.error)
+        if (account.error) return console.error(account.error)
+        vnode.state.assets = assets
+
+        vnode.state.sources = getHoldings(account.holdings, vnode.attrs.source)
+        vnode.state.targets = getHoldings(account.holdings, vnode.attrs.target)
+
+        if (vnode.attrs.source) {
+          vnode.state.sourceLabel = vnode.attrs.source
+          vnode.state.offer.source = vnode.state.sources[0].id
+        }
+
+        if (vnode.attrs.target) {
+          vnode.state.targetLabel = vnode.attrs.target
+          vnode.state.offer.target = vnode.state.sources[0].id
+        }
+      })
+  },
+
+  view (vnode) {
+    const assets = _.get(vnode.state, 'assets', [])
+    const sources = _.get(vnode.state, 'sources', [])
+    const targets = _.get(vnode.state, 'targets', [])
+    const sourceOptions = getOptions(sources, vnode.state)
+    const targetOptions = getOptions(targets, vnode.state, 'target')
+
+    const setter = path => value => _.set(vnode.state, path, value)
+    const intSetter = path => int => {
+      _.set(vnode.state, path, window.parseInt(int))
+    }
+
+    if (!vnode.attrs.target) {
+      Array.prototype.push.apply(targetOptions, optionsTail(vnode.state))
+    }
+
+    return modals.base(
+      modals.header('Create Offer', vnode.attrs.cancelFn),
+      modals.body(
+        m('.container', [
+          layout.row([
+            forms.textInput(setter('offer.label'), 'Label', false),
+            forms.textInput(setter('offer.description'), 'Description', false)
+          ]),
+          mkt.bifold({
+            header: layout.dropdown(
+              getLabel(vnode.state.sourceLabel, 'Offered'),
+              sourceOptions,
+              'success'),
+            body: forms.field(intSetter('offer.sourceQuantity'), {
+              type: 'number'
+            })
+          }, {
+            header: layout.dropdown(
+              getLabel(vnode.state.targetLabel, 'Requested'),
+              targetOptions,
+              'success'),
+            body: forms.field(intSetter('offer.targetQuantity'), {
+              type: 'number',
+              required: false,
+              disabled: vnode.state.noTarget
+            })
+          }),
+          !vnode.state.hasNewHolding
+            ? null
+            : forms.group('New Holding', [
+              assetDropdown(
+                vnode.state.holding.asset,
+                assets,
+                setter('holding.asset')),
+              layout.row([
+                holdingField('Label', setter('holding.label')),
+                holdingField('Description', setter('holding.description'))
+              ])
+            ])
+        ])),
+      modals.footer(
+        modals.button('Cancel', vnode.attrs.cancelFn, 'secondary'),
+        modals.button(
+          'Create',
+          submitter(vnode.state, vnode.attrs.acceptFn),
+          'primary',
+          { disabled: !isFormValid(vnode.state) })))
+  }
+}
+
+/**
+ * Displays a modal which will guide the user through creating an Offer
+ */
+const createOffer = (source = null, target = null) => {
+  return modals.show(CreateOfferModal, { source, target })
+    .catch(() => console.log('Creating offer canceled'))
+}
+
+module.exports = { createOffer }


### PR DESCRIPTION
Adds a modal which can be accessed from the Asset list and detail pages. Allows you to create an Offer as well as a new Holding if desired. Should be mostly complete, including a section for rules.

Built on #59 

_Screenshots:_
![screen shot 2017-12-18 at 1 07 41 am](https://user-images.githubusercontent.com/8889580/34093848-2ab4c9e0-e390-11e7-8b51-ae587ac49d76.png)
