### PR TITLE
Add Accept Offer modal to Offer pages

### DIFF
--- a/rest_api/api-spec.yaml
+++ b/rest_api/api-spec.yaml
@@ -309,14 +309,7 @@ paths:
             $ref: '#/definitions/AcceptOfferBody'
       responses:
         200:
-          description: Success response with the updated Holdings
-          schema:
-            type: object
-            properties:
-              source:
-                $ref: '#/definitions/HoldingObject'
-              target:
-                $ref: '#/definitions/HoldingObject'
+          description: Success response indicating offer has been accepted
         400:
           $ref: '#/responses/400BadRequest'
         401:
@@ -335,9 +328,7 @@ paths:
         - AuthToken: []
       responses:
         200:
-          description: Success response with the updated Offer
-          schema:
-            $ref: '#/definitions/OfferObject'
+          description: Success response indicating Offer was closed
         400:
           $ref: '#/responses/400BadRequest'
         401:

--- a/rest_api/api-spec.yaml
+++ b/rest_api/api-spec.yaml
@@ -663,7 +663,6 @@ definitions:
     description: Details provided in body to accept an Offer
     type: object
     required:
-      - source
       - count
       - target
     properties:

--- a/rest_api/api/offers.py
+++ b/rest_api/api/offers.py
@@ -94,15 +94,6 @@ async def accept_offer(request, offer_id):
     offer = await offers_query.fetch_offer_resource(
         request.app.config.DB_CONN, offer_id)
 
-    keys = ['source', 'target']
-    holdings = await fetch_holdings([
-        request.json.get(k) for k in keys if request.json.get(k) is not None
-    ]).run(request.app.config.DB_CONN)
-
-    holdings_dict = {
-        k: h for h in holdings for k in keys if request.json.get(k) == h['id']
-    }
-
     signer = await common.get_signer(request)
     batches, batch_id = transaction_creation.accept_offer(
         txn_key=signer,
@@ -121,10 +112,7 @@ async def accept_offer(request, offer_id):
 
     await messaging.check_batch_status(request.app.config.VAL_CONN, batch_id)
 
-    updated_holdings_dict = _calculate_accept_offer(
-        holdings_dict, offer, request.json['count'])
-
-    return response.json(updated_holdings_dict)
+    return response.json('')
 
 
 @OFFERS_BP.patch('offers/<offer_id>/close')
@@ -144,22 +132,7 @@ async def close_offer(request, offer_id):
 
     await messaging.check_batch_status(request.app.config.VAL_CONN, batch_id)
 
-    updated_offer = await offers_query.fetch_offer_resource(
-        request.app.config.DB_CONN, offer_id)
-    updated_offer['status'] = "CLOSED"
-
-    return response.json(updated_offer)
-
-
-def _calculate_accept_offer(holdings_dict, offer, count):
-    input_quantity = offer['sourceQuantity'] * count
-    holdings_dict['target']['quantity'] += input_quantity
-
-    if holdings_dict.get('source'):
-        output_quantity = offer['targetQuantity'] * count
-        holdings_dict['source']['quantity'] -= output_quantity
-
-    return holdings_dict
+    return response.json('')
 
 
 def _create_offer_dict(body, public_key):

--- a/rest_api/db/assets_query.py
+++ b/rest_api/db/assets_query.py
@@ -27,8 +27,6 @@ async def fetch_all_asset_resources(conn):
                 & (fetch_latest_block_num() < r.row['end_block_num']))\
         .map(lambda asset: (asset['description'] == "").branch(
             asset.without('description'), asset))\
-        .map(lambda asset: (asset['rules'] == []).branch(
-            asset.without('rules'), asset))\
         .without('start_block_num', 'end_block_num', 'delta_id')\
         .coerce_to('array').run(conn)
 
@@ -40,8 +38,6 @@ async def fetch_asset_resource(conn, name):
             .max('start_block_num')\
             .do(lambda asset: (asset['description'] == "").branch(
                 asset.without('description'), asset))\
-            .do(lambda asset: (asset['rules'] == []).branch(
-                asset.without('rules'), asset))\
             .without('start_block_num', 'end_block_num', 'delta_id')\
             .run(conn)
     except ReqlNonExistenceError:

--- a/rest_api/db/offers_query.py
+++ b/rest_api/db/offers_query.py
@@ -37,8 +37,6 @@ async def fetch_all_offer_resources(conn, query_params):
         .map(lambda offer: (offer['target_quantity'] == "").branch(
             offer,
             offer.merge({'targetQuantity': offer['target_quantity']})))\
-        .map(lambda offer: (offer['rules'] == []).branch(
-            offer.without('rules'), offer))\
         .without('delta_id', 'start_block_num', 'end_block_num',
                  'source_quantity', 'target_quantity')\
         .coerce_to('array').run(conn)
@@ -59,8 +57,6 @@ async def fetch_offer_resource(conn, offer_id):
             .do(lambda offer: (offer['target_quantity'] == "").branch(
                 offer,
                 offer.merge({'targetQuantity': offer['target_quantity']})))\
-            .do(lambda offer: (offer['rules'] == []).branch(
-                offer.without('rules'), offer))\
             .without('delta_id', 'start_block_num', 'end_block_num',
                      'source_quantity', 'target_quantity')\
             .run(conn)

--- a/sawbuck_app/src/components/layout.js
+++ b/sawbuck_app/src/components/layout.js
@@ -74,7 +74,8 @@ const dropdown = (label, options, color = 'primary') => {
       type: 'button',
       'data-toggle': 'dropdown',
       'aria-haspopup': 'true',
-      'aria-expanded': 'false'
+      'aria-expanded': 'false',
+      disabled: options.length === 0
     }, label),
     m('.dropdown-menu',
       options.map(option => {

--- a/sawbuck_app/src/components/marketplace.js
+++ b/sawbuck_app/src/components/marketplace.js
@@ -35,12 +35,12 @@ const holding = (header, body, color = 'success') => {
 /**
  * Returns two holding cards in a row with a large arrow between
  */
-const bifold = (left, right) => {
+const bifold = (left, right, direction = 'left') => {
   return m('.row.mb-5', [
     m('.col-md-5',
       holding(left.header, left.body, left.color)),
     m('.col-md-2.text-center',
-      m('.my-auto', layout.icon('arrow-right', {height: 60}))),
+      m('.my-auto', layout.icon(`arrow-${direction}`, {height: 60}))),
     m('.col-md-5',
       holding(right.header, right.body, right.color))
   ])

--- a/sawbuck_app/src/views/accept_offer_modal.js
+++ b/sawbuck_app/src/views/accept_offer_modal.js
@@ -1,0 +1,226 @@
+/**
+ * Copyright 2017 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ----------------------------------------------------------------------------
+ */
+'use strict'
+
+const m = require('mithril')
+const _ = require('lodash')
+
+const api = require('../services/api')
+const forms = require('../components/forms')
+const layout = require('../components/layout')
+const mkt = require('../components/marketplace')
+const modals = require('../components/modals')
+
+// Returns a label string, truncated if necessary
+const truncatedLabel = (value, defaultValue, max = 11) => {
+  const label = value || defaultValue
+  if (label.length <= max) return label
+  return `${label.slice(0, max - 3)}...`
+}
+
+// Returns a green check mark if visible
+const checkMark = (isVisible = true) => {
+  return m(`span.text-${isVisible ? 'success' : 'white'}`,
+           layout.icon('check'),
+           ' ')
+}
+
+// Small fields with placeholders rather than headers, for new holdings
+const holdingField = (placeholder, onValue) => {
+  return forms.field(onValue, { placeholder, required: false })
+}
+
+// Returns a function which sets id, label, and new for outgoing holdings
+const outSetter = state => holding => () => {
+  state.acceptance.out = holding.id
+  state.outLabel = holding.asset
+  state.outMax = holding.quantity
+}
+
+// Returns a function which sets id and label keys for the incoming holdings
+const inSetter = state => (holding, hasNew) => () => {
+  state.acceptance.in = holding.id
+  state.inLabel = holding.asset
+  state.hasNewHolding = hasNew
+}
+
+const countSetter = state => inQuantity => {
+  let count = Math.floor(inQuantity / state.offer.sourceQuantity)
+  if (inQuantity !== 0) count = Math.max(count, 1)
+
+  const exchangeOnce = state.offer.rules.find(({ type }) => {
+    return type.slice(0, 13) === 'EXCHANGE_ONCE'
+  })
+  if (exchangeOnce) count = Math.min(count, 1)
+
+  if (count * state.offer.targetQuantity > state.outMax) {
+    count = Math.floor(state.outMax / state.offer.sourceQuantity)
+  }
+
+  state.acceptance.count = count
+  state.inQuantity = count * state.offer.sourceQuantity
+  state.outQuantity = count * state.offer.targetQuantity
+}
+
+// Returns a function to map holding data to dropdown options
+const optionMapper = (state, key = 'in') => {
+  const setter = key !== 'out' ? inSetter(state) : outSetter(state)
+
+  return holding => ({
+    isSelected: () => state.acceptance[key] === holding.id,
+    text: `${holding.asset} (${holding.label || holding.id})`,
+    onclick: setter(holding, false)
+  })
+}
+
+// Returns a dropdown option which will trigger holding creation
+const newOption = state => ({
+  isSelected: () => !!state.hasNewHolding,
+  text: m('em', 'New Holding'),
+  onclick: inSetter(state)({ asset: 'New Holding' }, true)
+})
+
+// Adds a check mark to the appropriate holding option
+const checkMarkMapper = (state, key = 'in') => option => {
+  return _.assign({}, option, {
+    text: [
+      checkMark(option.isSelected()),
+      option.text
+    ]
+  })
+}
+
+// Returns true or false depending on whether or not the form is valid
+const isFormValid = state => !!state.acceptance.count
+
+// Returns a function which will submit a new offer, and holding if applicable
+const submitter = (state, onDone) => () => {
+  return Promise.resolve()
+    .then(() => {
+      if (state.hasNewHolding) {
+        const holdingKeys = ['label', 'description', 'asset']
+        return api.post('holdings', _.pick(state.holding, holdingKeys))
+      }
+    })
+    .then(holding => {
+      const acceptance = {
+        count: state.acceptance.count,
+        target: state.acceptance.in
+      }
+      if (state.acceptance.out) acceptance.source = state.acceptance.out
+      if (holding) acceptance.target = holding.id
+      return api.patch(`offers/${state.offer.id}/accept`, acceptance)
+    })
+    .then(onDone)
+    .then(() => m.route.set('/'))
+}
+
+const getAsset = (id, holdings) => {
+  return holdings.find(holding => holding.id === id).asset
+}
+
+// A versatile modal allowing users to create new offers (and new holdings)
+const AcceptOfferModal = {
+  oninit (vnode) {
+    vnode.state.holding = {}
+    vnode.state.acceptance = {}
+    vnode.state.hasNewHolding = false
+
+    api.get(`offers/${vnode.attrs.offerId}`)
+      .then(offer => {
+        if (offer.error) return console.error(offer.error)
+        vnode.state.offer = offer
+
+        return Promise.all([
+          api.get(`accounts/${api.getPublicKey()}`),
+          api.get(`accounts/${offer.owners[0]}`)
+        ])
+      })
+      .then(([ user, owner ]) => {
+        const inAsset = getAsset(vnode.state.offer.source, owner.holdings)
+        vnode.state.holding.asset = inAsset
+        vnode.state.inOptions = user.holdings
+          .filter(holding => holding.asset === inAsset)
+          .map(optionMapper(vnode.state))
+          .concat(newOption(vnode.state))
+        vnode.state.inOptions[0].onclick()
+
+        if (vnode.state.offer.target) {
+          const outAsset = getAsset(vnode.state.offer.target, owner.holdings)
+          vnode.state.outOptions = user.holdings
+            .filter(holding => holding.asset === outAsset)
+            .map(optionMapper(vnode.state, 'out'))
+          vnode.state.outOptions[0].onclick()
+        } else {
+          vnode.state.outLabel = 'free'
+        }
+      })
+  },
+
+  view (vnode) {
+    const setter = path => value => _.set(vnode.state, path, value)
+    const inOptions = _.get(vnode.state, 'inOptions', [])
+      .map(checkMarkMapper(vnode.state))
+    const outOptions = _.get(vnode.state, 'outOptions', [])
+      .map(checkMarkMapper(vnode.state, 'out'))
+
+    return modals.base(
+      modals.header('Accept Offer', vnode.attrs.cancelFn),
+      modals.body(
+        m('.container', [
+          mkt.bifold({
+            header: layout.dropdown(
+              truncatedLabel(vnode.state.inLabel, 'Offered'),
+              inOptions,
+              'success'),
+            body: forms.field(countSetter(vnode.state), {
+              type: 'number',
+              onblur: ({ target }) => { target.value = vnode.state.inQuantity }
+            })
+          }, {
+            header: layout.dropdown(
+              truncatedLabel(vnode.state.outLabel, 'Requested'),
+              outOptions,
+              'success'),
+            body: vnode.state.outQuantity || '---'
+          }),
+          !vnode.state.hasNewHolding
+            ? null
+            : forms.group('New Holding', layout.row([
+              holdingField('Label', setter('holding.label')),
+              holdingField('Description', setter('holding.description'))
+            ]))
+        ])),
+      modals.footer(
+        modals.button('Cancel', vnode.attrs.cancelFn, 'secondary'),
+        modals.button(
+          'Accept',
+          submitter(vnode.state, vnode.attrs.acceptFn),
+          'primary',
+          { disabled: !isFormValid(vnode.state) })))
+  }
+}
+
+/**
+ * Displays a modal which will guide the user through accepting an Offer
+ */
+const acceptOffer = offerId => {
+  return modals.show(AcceptOfferModal, { offerId })
+    .catch(() => console.log('Accepting offer canceled'))
+}
+
+module.exports = { acceptOffer }

--- a/sawbuck_app/src/views/create_offer_modal.js
+++ b/sawbuck_app/src/views/create_offer_modal.js
@@ -244,7 +244,7 @@ const CreateOfferModal = {
               required: false,
               disabled: vnode.state.noTarget
             })
-          }),
+          }, 'right'),
           !vnode.state.hasNewHolding
             ? null
             : forms.group('New Holding', [

--- a/sawbuck_app/src/views/offer_detail.js
+++ b/sawbuck_app/src/views/offer_detail.js
@@ -22,6 +22,7 @@ const _ = require('lodash')
 const api = require('../services/api')
 const layout = require('../components/layout')
 const mkt = require('../components/marketplace')
+const { acceptOffer } = require('./accept_offer_modal')
 
 const findAsset = (id, holdings) => holdings.find(h => h.id === id).asset
 
@@ -112,7 +113,7 @@ const OfferDetailPage = {
           m('.col-md.m-3',
             acceptButton(
               name,
-              () => console.log(`Accepting offer ${offer.id}...`),
+              () => acceptOffer(offer.id),
               vnode.state.disabled))))
     ]
   }

--- a/sawbuck_app/src/views/offer_list.js
+++ b/sawbuck_app/src/views/offer_list.js
@@ -22,6 +22,7 @@ const _ = require('lodash')
 const api = require('../services/api')
 const layout = require('../components/layout')
 const mkt = require('../components/marketplace')
+const { acceptOffer } = require('./accept_offer_modal')
 
 const filterDropdown = (label, assets, setter) => {
   const options = assets.map(asset => ({
@@ -37,7 +38,7 @@ const filterDropdown = (label, assets, setter) => {
 }
 
 const acceptButton = (offer, account = null) => {
-  const onclick = () => console.log(`Accepting offer ${offer.id}...`)
+  const onclick = () => acceptOffer(offer.id)
   let disabled = false
   if (!account) disabled = true
   else if (offer.targetQuantity === 0) disabled = false


### PR DESCRIPTION
Adds an Accept Offer Modal, which also allows for Holding creation. Also reverse the direction of the bifold arrow in most contexts. The direction of the arrow no reflects the direction of the flow of assets, relative to the user.

_Screenshots:_
![screen shot 2017-12-20 at 1 17 32 pm](https://user-images.githubusercontent.com/8889580/34222138-8a028dca-e588-11e7-9bbc-c28c31f4fce4.png)

