### PR TITLE
Add error handing to Sawbuck app

### DIFF
--- a/sawbuck_app/src/services/api.js
+++ b/sawbuck_app/src/services/api.js
@@ -84,6 +84,24 @@ const get = _.partial(request, 'GET')
 const post = _.partial(request, 'POST')
 const patch = _.partial(request, 'PATCH')
 
+/**
+ * Sends the user an alert with the error message and reloads the page.
+ * Appropriate for requests triggered by user action.
+ */
+const alertError = err => {
+  console.error(err)
+  window.alert(err.error || err.message || err)
+  window.location.reload()
+}
+
+/**
+ * Logs the error but otherwise ignores it.
+ * Appropriate for requests triggered in the background.
+ */
+const ignoreError = err => {
+  console.error(err)
+}
+
 module.exports = {
   getAuth,
   setAuth,
@@ -92,5 +110,7 @@ module.exports = {
   request,
   get,
   post,
-  patch
+  patch,
+  alertError,
+  ignoreError
 }

--- a/sawbuck_app/src/views/accept_offer_modal.js
+++ b/sawbuck_app/src/views/accept_offer_modal.js
@@ -126,7 +126,8 @@ const submitter = (state, onDone) => () => {
       return api.patch(`offers/${state.offer.id}/accept`, acceptance)
     })
     .then(onDone)
-    .then(() => m.route.set('/'))
+    .then(() => m.route.set('/account'))
+    .catch(api.alertError)
 }
 
 const getAsset = (id, holdings) => {

--- a/sawbuck_app/src/views/account_detail.js
+++ b/sawbuck_app/src/views/account_detail.js
@@ -72,6 +72,7 @@ const editField = (state, label, key) => {
   const onSubmit = () => {
     return api.patch('accounts', _.pick(state.update, key))
       .then(() => { state.account[key] = state.update[key] })
+      .catch(api.alertError)
   }
 
   return labeledField(
@@ -88,6 +89,7 @@ const passwordField = state => {
       password: state.update.password
     })
       .then(() => m.redraw())
+      .catch(api.alertError)
   }
 
   return labeledField(
@@ -118,6 +120,7 @@ const AccountDetailPage = {
     vnode.state.update = {}
     api.get(`accounts/${vnode.attrs.publicKey}`)
       .then(account => { vnode.state.account = account })
+      .catch(api.ignoreError)
   },
 
   view (vnode) {

--- a/sawbuck_app/src/views/asset_detail.js
+++ b/sawbuck_app/src/views/asset_detail.js
@@ -61,6 +61,7 @@ const AssetDetailPage = {
         }
       })
       .then(owner => { if (owner) vnode.state.owner = owner })
+      .catch(api.ignoreError)
   },
 
   view (vnode) {

--- a/sawbuck_app/src/views/asset_list.js
+++ b/sawbuck_app/src/views/asset_list.js
@@ -73,6 +73,7 @@ const AssetListPage = {
           vnode.state.account = _.assign({ quantities }, account)
         }
       })
+      .catch(api.ignoreError)
   },
 
   view (vnode) {

--- a/sawbuck_app/src/views/create_offer_modal.js
+++ b/sawbuck_app/src/views/create_offer_modal.js
@@ -167,7 +167,8 @@ const submitter = (state, onDone) => () => {
       return api.post('offers', offer)
     })
     .then(onDone)
-    .then(() => m.route.set('/'))
+    .then(() => m.route.set('/offers'))
+    .catch(api.alertError)
 }
 
 // A versatile modal allowing users to create new offers (and new holdings)

--- a/sawbuck_app/src/views/login_form.js
+++ b/sawbuck_app/src/views/login_form.js
@@ -41,6 +41,7 @@ const LoginForm = {
               api.setAuth(res.authorization)
               m.route.set('/')
             })
+            .catch(api.alertError)
         }
       },
       m('legend', 'Login Account'),

--- a/sawbuck_app/src/views/offer_detail.js
+++ b/sawbuck_app/src/views/offer_detail.js
@@ -73,6 +73,7 @@ const OfferDetailPage = {
         offer.targetAsset = findAsset(offer.target, owner.holdings)
         vnode.state.owner = owner
       })
+      .catch(api.ignoreError)
   },
 
   view (vnode) {

--- a/sawbuck_app/src/views/offer_list.js
+++ b/sawbuck_app/src/views/offer_list.js
@@ -111,6 +111,7 @@ const OfferListPage = {
           vnode.state.account = _.assign({ quantities }, account)
         }
       })
+      .catch(api.ignoreError)
   },
 
   view (vnode) {

--- a/sawbuck_app/src/views/signup_form.js
+++ b/sawbuck_app/src/views/signup_form.js
@@ -31,6 +31,7 @@ const accountSubmitter = state => e => {
   api.post('accounts', account)
     .then(res => api.setAuth(res.authorization))
     .then(() => m.route.set('/'))
+    .catch(api.alertError)
 }
 
 /**


### PR DESCRIPTION
Errors on background API requests will be logged, but otherwise ignored, and API requests triggered by user actions (i.e. form submissions) will trigger an alert, and then clear the form.

A common example would be to attempting to login with bad credentials, or trying to load any page when the api is down. You can kill the API with:

```bash
docker container stop sawtoothmarketplace_market-rest-api_1
```