### PR TITLE
EXCHANGE_LIMITED_TO_ACCOUNTS functionality

### DIFF
--- a/addressing/marketplace_addressing/addresser.py
+++ b/addressing/marketplace_addressing/addresser.py
@@ -128,18 +128,20 @@ def address_is(address):
     infix = int(address[6:8], 16)
 
     if _contains(infix, OfferHistorySpace):
-        return AddressSpace.OFFER_HISTORY
+        result = AddressSpace.OFFER_HISTORY
 
     elif _contains(infix, AssetSpace):
-        return AddressSpace.ASSET
+        result = AddressSpace.ASSET
 
     elif _contains(infix, HoldingSpace):
-        return AddressSpace.HOLDING
+        result = AddressSpace.HOLDING
 
     elif _contains(infix, AccountSpace):
-        return AddressSpace.ACCOUNT
+        result = AddressSpace.ACCOUNT
 
     elif _contains(infix, OfferSpace):
-        return AddressSpace.OFFER
+        result = AddressSpace.OFFER
     else:
-        return AddressSpace.OTHER_FAMILY
+        result = AddressSpace.OTHER_FAMILY
+
+    return result

--- a/dev_env/Dockerfile
+++ b/dev_env/Dockerfile
@@ -33,7 +33,7 @@ RUN curl -sL https://deb.nodesource.com/setup_6.x | bash - \
     && apt-get install -y nodejs
 
 RUN pip3 install \
-    pylint==1.7.4 \
+    pylint==1.8.1 \
     pycodestyle==2.3.1 \
     grpcio-tools==1.7.0 \
     nose2==0.7.2 \

--- a/integration_tests/rest_api/setup_data_hooks.py
+++ b/integration_tests/rest_api/setup_data_hooks.py
@@ -49,8 +49,8 @@ ASSET = {
         },
         {
             'type': 'EXCHANGE_LIMITED_TO_ACCOUNTS',
-            'value': (['02178c1bcdb25407394348f1ff5273ada'
-                      'e287d8ea328184546837957e71c7de57a'])
+            'value': ['02178c1bcdb25407394348f1ff5273ada'
+                      'e287d8ea328184546837957e71c7de57a']
         }
     ]
 }
@@ -103,8 +103,8 @@ OFFER = {
         },
         {
             'type': 'EXCHANGE_LIMITED_TO_ACCOUNTS',
-            'value': (['02178c1bcdb25407394348f1ff5273ada'
-                      'e287d8ea328184546837957e71c7de57a'])
+            'value': ['02178c1bcdb25407394348f1ff5273ada'
+                      'e287d8ea328184546837957e71c7de57a']
         }
     ]
 }
@@ -154,6 +154,13 @@ def sub_nested_strings(dct, pattern, replacement):
             sub_nested_strings(dct[key], pattern, replacement)
         elif isinstance(dct[key], str):
             dct[key] = re.sub(pattern, replacement, dct[key])
+        elif isinstance(dct[key], list):
+            for item in dct[key]:
+                if isinstance(item, dict):
+                    sub_nested_strings(item, pattern, replacement)
+            dct[key] = [re.sub(pattern, replacement, item)
+                        for item in dct[key] if isinstance(item, str)]
+
 
 
 @hooks.before_all
@@ -167,6 +174,10 @@ def initialize_sample_resources(txns):
     seeded_data['account'] = account_response['account']
 
     # Create ASSET
+    for spec_id, id_getter in INVALID_SPEC_IDS:
+        if spec_id == '02178c1bcdb25407394348f1ff5273adae287d8ea328184546837957e71c7de57a':
+            sub_nested_strings(ASSET, spec_id, id_getter(seeded_data))
+
     seeded_data['asset'] = submit('assets', ASSET)
     seeded_data['asset_2'] = submit('assets', ASSET_2)
 
@@ -184,6 +195,9 @@ def initialize_sample_resources(txns):
     # Create OFFER
     OFFER['source'] = seeded_data['holding']['id']
     OFFER['target'] = seeded_data['holding_3']['id']
+    for spec_id, id_getter in INVALID_SPEC_IDS:
+        if spec_id == '02178c1bcdb25407394348f1ff5273adae287d8ea328184546837957e71c7de57a':
+            sub_nested_strings(OFFER, spec_id, id_getter(seeded_data))
     seeded_data['offer'] = submit('offers', OFFER)
 
     # Replace example auth and identifiers with ones from seeded data

--- a/ledger_sync/marketplace_ledger_sync/deltas/decoding.py
+++ b/ledger_sync/marketplace_ledger_sync/deltas/decoding.py
@@ -39,7 +39,7 @@ def data_to_dicts(address, data):
     """
     data_type = address_is(address)
 
-    if (IGNORE.get(data_type)):
+    if IGNORE.get(data_type):
         return []
 
     try:

--- a/ledger_sync/marketplace_ledger_sync/deltas/handlers.py
+++ b/ledger_sync/marketplace_ledger_sync/deltas/handlers.py
@@ -16,9 +16,10 @@
 import re
 import logging
 
+from sawtooth_sdk.protobuf.transaction_receipt_pb2 import StateChangeList
+
 from marketplace_ledger_sync.deltas.decoding import data_to_dicts
 from marketplace_ledger_sync.deltas.updating import get_updater
-from sawtooth_sdk.protobuf.transaction_receipt_pb2 import StateChangeList
 from marketplace_addressing.addresser import NS as NAMESPACE
 
 


### PR DESCRIPTION
~~This is based on #69 and #71. Only the last commit is of this PR. If there are multiple EXCHANGE_LIMITED_TO_ACCOUNTS rules -- if one is from an asset and one is from the offer -- the rule is that it is limited to the union of the accounts.~~   If there are multiple EXCHANGE_LIMITED_TO_ACCOUNTS rules the intersection of the values is taken.