### PR TITLE
Implement SawbuckManager fixes raised at demo

### DIFF
--- a/sawbuck_app/app_data.yaml
+++ b/sawbuck_app/app_data.yaml
@@ -15,25 +15,25 @@
 
 ACCOUNTS:
 
-  - label: US Federal Reserve
-    description: The central banking system of the United States
-    email: fed@us.gov
+  - label: Minicoin Reserve
+    description: The sole issuing authoririty for Minicoins
+    email: minicoin@minicoin.net
     password: password
     ASSETS:
-      - name: USD
-        description: United States Dollars (in thousandths of a cent)
+      - name: Minicoin
+        description: The cryptocurrency that fits in your pocket
         rules:
           - type: OWNER_HOLDINGS_INFINITE
     HOLDINGS:
-      - label: US Mint
-        description: An unlimited supply of printable dollars
-        asset: USD
+      - label: Minicoin Source
+        description: An unlimited supply new minicoin
+        asset: Minicoin
         quantity: 9007199254740991
     OFFERS:
-      - label: Account Provision
-        description: A one-time payout of 100 USD for each Account
-        source: $REF=HOLDINGS[label:US Mint].id
-        sourceQuantity: 10000000
+      - label: Minicoin Provision
+        description: A one time payout of 1 million minicoin
+        source: $REF=HOLDINGS[label:Minicoin Source].id
+        sourceQuantity: 1000000
         rules:
           - type: EXCHANGE_ONCE_PER_ACCOUNT
     RENEWABLES: []

--- a/sawbuck_app/src/views/accept_offer_modal.js
+++ b/sawbuck_app/src/views/accept_offer_modal.js
@@ -26,7 +26,7 @@ const mkt = require('../components/marketplace')
 const modals = require('../components/modals')
 
 // Returns a label string, truncated if necessary
-const truncatedLabel = (value, defaultValue, max = 11) => {
+const truncatedLabel = (value, defaultValue, max = 10) => {
   const label = value || defaultValue
   if (label.length <= max) return label
   return `${label.slice(0, max - 3)}...`
@@ -90,8 +90,8 @@ const optionMapper = (state, key = 'in') => {
 // Returns a dropdown option which will trigger holding creation
 const newOption = state => ({
   isSelected: () => !!state.hasNewHolding,
-  text: m('em', 'New Holding'),
-  onclick: inSetter(state)({ asset: 'New Holding' }, true)
+  text: m('em', 'new (New Holding)'),
+  onclick: inSetter(state)({ asset: 'new' }, true)
 })
 
 // Adds a check mark to the appropriate holding option

--- a/sawbuck_app/src/views/accept_offer_modal.js
+++ b/sawbuck_app/src/views/accept_offer_modal.js
@@ -169,6 +169,9 @@ const AcceptOfferModal = {
         } else {
           vnode.state.outLabel = 'free'
         }
+
+        // Set initial count/quantity values to the minimum exchange
+        countSetter(vnode.state)(1)
       })
   },
 
@@ -190,6 +193,7 @@ const AcceptOfferModal = {
               'success'),
             body: forms.field(countSetter(vnode.state), {
               type: 'number',
+              defaultValue: vnode.state.inQuantity,
               onblur: ({ target }) => { target.value = vnode.state.inQuantity }
             })
           }, {

--- a/sawbuck_app/src/views/accept_offer_modal.js
+++ b/sawbuck_app/src/views/accept_offer_modal.js
@@ -19,6 +19,7 @@
 const m = require('mithril')
 const _ = require('lodash')
 
+const acct = require('../services/account')
 const api = require('../services/api')
 const forms = require('../components/forms')
 const layout = require('../components/layout')
@@ -147,7 +148,7 @@ const AcceptOfferModal = {
         vnode.state.offer = offer
 
         return Promise.all([
-          api.get(`accounts/${api.getPublicKey()}`),
+          acct.getUserAccount(),
           api.get(`accounts/${offer.owners[0]}`)
         ])
       })

--- a/sawbuck_app/src/views/accept_offer_modal.js
+++ b/sawbuck_app/src/views/accept_offer_modal.js
@@ -186,6 +186,8 @@ const AcceptOfferModal = {
       modals.header('Accept Offer', vnode.attrs.cancelFn),
       modals.body(
         m('.container', [
+          m('.text-muted.mb-2',
+            `Enter how much ${vnode.state.holding.asset} you would like`),
           mkt.bifold({
             header: layout.dropdown(
               truncatedLabel(vnode.state.inLabel, 'Offered'),

--- a/sawbuck_app/src/views/accept_offer_modal.js
+++ b/sawbuck_app/src/views/accept_offer_modal.js
@@ -132,6 +132,8 @@ const submitter = (state, onDone) => () => {
     })
     .then(onDone)
     .then(() => m.route.set('/account'))
+    .then(() => new Promise(resolve => setTimeout(resolve, 2000)))
+    .then(() => window.location.reload())
     .catch(api.alertError)
 }
 

--- a/sawbuck_app/src/views/account_detail.js
+++ b/sawbuck_app/src/views/account_detail.js
@@ -19,6 +19,7 @@
 const m = require('mithril')
 const _ = require('lodash')
 
+const acct = require('../services/account')
 const api = require('../services/api')
 const forms = require('../components/forms')
 const layout = require('../components/layout')
@@ -118,8 +119,18 @@ const AccountDetailPage = {
   oninit (vnode) {
     vnode.state.toggled = {}
     vnode.state.update = {}
-    api.get(`accounts/${vnode.attrs.publicKey}`)
-      .then(account => { vnode.state.account = account })
+
+    Promise.resolve()
+      .then(() => {
+        if (vnode.attrs.publicKey === api.getPublicKey()) {
+          return acct.getUserAccount()
+        }
+        return api.get(`accounts/${vnode.attrs.publicKey}`)
+      })
+      .then(account => {
+        vnode.state.account = account
+        m.redraw()
+      })
       .catch(api.ignoreError)
   },
 

--- a/sawbuck_app/src/views/create_offer_modal.js
+++ b/sawbuck_app/src/views/create_offer_modal.js
@@ -223,6 +223,11 @@ const CreateOfferModal = {
       modals.header('Create Offer', vnode.attrs.cancelFn),
       modals.body(
         m('.container', [
+          m('.text-muted.mb-2',
+            'Enter info for your new Offer ',
+            vnode.attrs.target
+              ? `requesting ${vnode.attrs.target}`
+              : `of ${vnode.attrs.source}`),
           layout.row([
             forms.textInput(setter('offer.label'), 'Label', false),
             forms.textInput(setter('offer.description'), 'Description', false)

--- a/sawbuck_app/src/views/create_offer_modal.js
+++ b/sawbuck_app/src/views/create_offer_modal.js
@@ -27,7 +27,7 @@ const mkt = require('../components/marketplace')
 const modals = require('../components/modals')
 
 // Returns a label string, truncated if necessary
-const getLabel = (value, defaultValue, max = 11) => {
+const getLabel = (value, defaultValue, max = 10) => {
   const label = value || defaultValue
   if (label.length <= max) return label
   return `${label.slice(0, max - 3)}...`
@@ -80,8 +80,8 @@ const optionsTail = state => {
     text: [check(state.noTarget === true), m('em', 'free (No Holding)')],
     onclick: targetSetter(state)(null, 'free', true)
   }, {
-    text: [check(state.hasNewHolding === true), m('em', 'New Holding')],
-    onclick: targetSetter(state)(null, 'New Holding', false, true)
+    text: [check(state.hasNewHolding === true), m('em', 'new (New Holding)')],
+    onclick: targetSetter(state)(null, 'new', false, true)
   }]
 }
 

--- a/sawbuck_app/src/views/create_offer_modal.js
+++ b/sawbuck_app/src/views/create_offer_modal.js
@@ -168,6 +168,8 @@ const submitter = (state, onDone) => () => {
     })
     .then(onDone)
     .then(() => m.route.set('/offers'))
+    .then(() => new Promise(resolve => setTimeout(resolve, 2000)))
+    .then(() => window.location.reload())
     .catch(api.alertError)
 }
 


### PR DESCRIPTION
Fixes Implemented:
- Remove references to USD
- default AcceptOffers to count of 1
- add 1 line of instructions to modals
- truncate labels at 10 char ("New Holding" needs to be shorter)
- validate that you don't go over the Offer owner's quantities
- find a way to make sure data has updated before redirecting on modal close

In addition, one bug was noted during the demo which was actually already implemented:
- don't allow non-owners to offer non-transferable assets