### PR TITLE
fixed python package version problems, sanic, websockets, uvloop

### DIFF
--- a/bin/market-setup-db
+++ b/bin/market-setup-db
@@ -18,8 +18,10 @@
 import sys
 import argparse
 
-import rethinkdb as r
+import rethinkdb as rdb
 from rethinkdb.errors import RqlRuntimeError
+
+r = None
 
 
 def parse_args(args):
@@ -37,6 +39,13 @@ def parse_args(args):
 
 
 def setup_db(host, port, name):
+    print("*"*60)
+    """
+    import rethinkdb as rdb
+    r = rdb.RethinkDB()
+    r.connect('localhost', 28015).repl()
+    """
+    r = rdb.RethinkDB()
     conn = r.connect(host=host, port=port)
     print('Connection opened')
     try:

--- a/dev_env/Dockerfile
+++ b/dev_env/Dockerfile
@@ -35,6 +35,7 @@ RUN curl -sL https://deb.nodesource.com/setup_6.x | bash - \
     && apt-get install -y nodejs
 
 RUN pip3 install \
+    coverage==4.4.1 \
     futures==2.2 \
     bcrypt==3.1.5 \
     ujson==3.1.0 \

--- a/dev_env/Dockerfile
+++ b/dev_env/Dockerfile
@@ -22,11 +22,11 @@ RUN echo "deb apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 
     apt-get update && \
     apt-get install -y --allow-unauthenticated -q \
         python3-pip \
+	python3-cffi \
         python3-sawtooth-sdk \
         python3-sawtooth-rest-api \
         python3-sawtooth-cli \
         python3-sawtooth-signing \
-	python3-bcrypt \
         cron-apt \
         curl \
 	wget
@@ -36,6 +36,7 @@ RUN curl -sL https://deb.nodesource.com/setup_6.x | bash - \
 
 RUN pip3 install \
     futures==2.2 \
+    bcrypt==3.1.5 \
     ujson==3.1.0 \
     uvloop==0.14 \
     pylint==1.8.1 \

--- a/dev_env/Dockerfile
+++ b/dev_env/Dockerfile
@@ -26,22 +26,30 @@ RUN echo "deb apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 
         python3-sawtooth-rest-api \
         python3-sawtooth-cli \
         python3-sawtooth-signing \
+	python3-setuptools-scm \
+	python3-websockets \
+	python3-grpcio \
+	pylint3 \
         cron-apt \
+	python3-cffi \	
         curl
+
+
 
 RUN curl -sL https://deb.nodesource.com/setup_6.x | bash - \
     && apt-get install -y nodejs
 
-RUN pip3 install \
-    pylint==1.8.1 \
-    pycodestyle==2.3.1 \
-    grpcio-tools==1.7.0 \
-    nose2==0.7.2 \
-    bcrypt \
-    pycrypto \
-    rethinkdb \
-    sanic \
-    itsdangerous
+# RUN pip3 install   pylint==1.8.1
+RUN pip3 install   pycodestyle==2.3.1
+#RUN pip3 install  grpcio-tools==1.7.0
+RUN pip3 install   nose2==0.7.2
+RUN pip3 install   bcrypt
+RUN pip3 install   pycrypto
+RUN pip3 install   rethinkdb
+RUN pip3 install uvloop==0.5.3
+RUN pip3 install websockets==4.0.1
+RUN pip3 install   sanic==0.7.0
+RUN pip3 install   itsdangerous
 
 WORKDIR /project/sawtooth-marketplace
 

--- a/dev_env/Dockerfile
+++ b/dev_env/Dockerfile
@@ -26,30 +26,26 @@ RUN echo "deb apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 
         python3-sawtooth-rest-api \
         python3-sawtooth-cli \
         python3-sawtooth-signing \
-	python3-setuptools-scm \
-	python3-websockets \
-	python3-grpcio \
-	pylint3 \
+	python3-bcrypt \
         cron-apt \
-	python3-cffi \	
-        curl
-
-
+        curl \
+	wget
 
 RUN curl -sL https://deb.nodesource.com/setup_6.x | bash - \
     && apt-get install -y nodejs
 
-# RUN pip3 install   pylint==1.8.1
-RUN pip3 install   pycodestyle==2.3.1
-#RUN pip3 install  grpcio-tools==1.7.0
-RUN pip3 install   nose2==0.7.2
-RUN pip3 install   bcrypt
-RUN pip3 install   pycrypto
-RUN pip3 install   rethinkdb
-RUN pip3 install uvloop==0.5.3
-RUN pip3 install websockets==4.0.1
-RUN pip3 install   sanic==0.7.0
-RUN pip3 install   itsdangerous
+RUN pip3 install \
+    futures==2.2 \
+    ujson==3.1.0 \
+    uvloop==0.14 \
+    pylint==1.8.1 \
+    pycodestyle==2.3.1 \
+    grpcio-tools==1.7.0 \
+    nose2==0.7.2 \
+    pycrypto \
+    rethinkdb \
+    sanic==0.8.3 \
+    itsdangerous==1.1.0
 
 WORKDIR /project/sawtooth-marketplace
 

--- a/dev_env/Dockerfile-installed
+++ b/dev_env/Dockerfile-installed
@@ -37,7 +37,7 @@ RUN pip3 install \
     pycodestyle==2.3.1 \
     grpcio-tools==1.7.0 \
     nose2==0.7.2 \
-    bcrypt \
+    bcrypt==3.1.5 \
     pycrypto \
     rethinkdb \
     sanic \

--- a/ledger_sync/marketplace_ledger_sync/database.py
+++ b/ledger_sync/marketplace_ledger_sync/database.py
@@ -14,8 +14,11 @@
 # -----------------------------------------------------------------------------
 
 import logging
-import rethinkdb as r
+import rethinkdb as rdb
 
+r = rdb.RethinkDB() 
+
+print(dir(r))
 
 LOGGER = logging.getLogger(__name__)
 
@@ -33,6 +36,7 @@ class Database(object):
         """Initializes a connection to the database
         """
         LOGGER.debug('Connecting to database: %s:%s', self._host, self._port)
+        
         self._conn = r.connect(host=self._host, port=self._port)
 
     def disconnect(self):

--- a/rest_api/Dockerfile
+++ b/rest_api/Dockerfile
@@ -20,23 +20,18 @@ RUN echo "deb apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 
     apt-get update && \
     apt-get install -y --allow-unauthenticated -q python3-grpcio-tools=1.1.3-1 \
         python3-pip \
+	python3-bcrypt \
         python3-sawtooth-sdk \
-	python3-cffi \
         python3-sawtooth-signing \
-        python3-sawtooth-rest-api
-
-RUN apt-get install -y --allow-unauthenticated \
-	python3-setuptools-scm \
-	python3-websockets 
-
-RUN pip3 install uvloop==0.5.3
-RUN pip3 install websockets==4.0.1
+        python3-sawtooth-rest-api \
+	curl
 
 RUN pip3 install \
-    bcrypt \
-    itsdangerous \
+    uvloop==0.14 \
+    ujson==3.1.0 \
+    itsdangerous==1.1.0 \
     rethinkdb \
-    sanic==0.7.0 \
+    sanic==0.8.3 \
     pycrypto
 
 WORKDIR /project/sawtooth-marketplace

--- a/rest_api/Dockerfile
+++ b/rest_api/Dockerfile
@@ -21,14 +21,22 @@ RUN echo "deb apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 
     apt-get install -y --allow-unauthenticated -q python3-grpcio-tools=1.1.3-1 \
         python3-pip \
         python3-sawtooth-sdk \
+	python3-cffi \
         python3-sawtooth-signing \
         python3-sawtooth-rest-api
+
+RUN apt-get install -y --allow-unauthenticated \
+	python3-setuptools-scm \
+	python3-websockets 
+
+RUN pip3 install uvloop==0.5.3
+RUN pip3 install websockets==4.0.1
 
 RUN pip3 install \
     bcrypt \
     itsdangerous \
     rethinkdb \
-    sanic \
+    sanic==0.7.0 \
     pycrypto
 
 WORKDIR /project/sawtooth-marketplace

--- a/rest_api/Dockerfile
+++ b/rest_api/Dockerfile
@@ -20,7 +20,7 @@ RUN echo "deb apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 
     apt-get update && \
     apt-get install -y --allow-unauthenticated -q python3-grpcio-tools=1.1.3-1 \
         python3-pip \
-	python3-bcrypt \
+	python3-cffi \
         python3-sawtooth-sdk \
         python3-sawtooth-signing \
         python3-sawtooth-rest-api \
@@ -28,6 +28,7 @@ RUN echo "deb apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 
 
 RUN pip3 install \
     uvloop==0.14 \
+    bcrypt==3.1.5 \
     ujson==3.1.0 \
     itsdangerous==1.1.0 \
     rethinkdb \

--- a/rest_api/Dockerfile-installed
+++ b/rest_api/Dockerfile-installed
@@ -20,14 +20,17 @@ RUN echo "deb apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 
     apt-get update && \
     apt-get install -y --allow-unauthenticated -q python3-grpcio-tools=1.1.3-1 \
         python3-pip \
+	python3-cffi
         python3-sawtooth-sdk \
         python3-sawtooth-rest-api
 
 RUN pip3 install \
-    bcrypt \
-    itsdangerous \
+    bcrypt==3.1.5 \
+    ujson==3.1.0 \
+    uvloop==0.14 \
+    itsdangerous==1.1.0 \
     rethinkdb \
-    sanic \
+    sanic==0.8.3 \
     pycrypto
 
 WORKDIR /project/sawtooth-marketplace

--- a/rest_api/api/main.py
+++ b/rest_api/api/main.py
@@ -20,7 +20,10 @@ import os
 from signal import signal, SIGINT
 import sys
 
-import rethinkdb as r
+import rethinkdb as rdb
+
+r = rdb.RethinkDB()
+
 
 from sanic import Sanic
 

--- a/rest_api/db/accounts_query.py
+++ b/rest_api/db/accounts_query.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
-import rethinkdb as r
+import rethinkdb as rdb
 from rethinkdb.errors import ReqlNonExistenceError
 
 from api.errors import ApiBadRequest
@@ -21,6 +21,7 @@ from api.errors import ApiBadRequest
 from db.common import fetch_holdings
 from db.common import fetch_latest_block_num
 
+r = rdb.RethinkDB()
 
 async def fetch_all_account_resources(conn):
     return await r.table('accounts')\

--- a/rest_api/db/assets_query.py
+++ b/rest_api/db/assets_query.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
-import rethinkdb as r
+import rethinkdb as rdb
 from rethinkdb.errors import ReqlNonExistenceError
 
 from api.errors import ApiBadRequest
@@ -21,6 +21,8 @@ from api.errors import ApiBadRequest
 from db.common import fetch_latest_block_num
 from db.common import parse_rules
 
+
+r = rdb.RethinkDB()
 
 async def fetch_all_asset_resources(conn):
     return await r.table('assets')\

--- a/rest_api/db/auth_query.py
+++ b/rest_api/db/auth_query.py
@@ -15,10 +15,11 @@
 
 import logging
 
-import rethinkdb as r
+import rethinkdb as rdb
 
 from api.errors import ApiBadRequest
 
+r = rdb.RethinkDB()
 
 LOGGER = logging.getLogger(__name__)
 

--- a/rest_api/db/common.py
+++ b/rest_api/db/common.py
@@ -13,8 +13,11 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
-import rethinkdb as r
-from rethinkdb import ReqlNonExistenceError
+import rethinkdb as rdb
+from rethinkdb.errors  import ReqlNonExistenceError
+
+r = rdb.RethinkDB()
+
 
 from api.errors import ApiInternalError
 

--- a/rest_api/db/offers_query.py
+++ b/rest_api/db/offers_query.py
@@ -13,13 +13,18 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
-import rethinkdb as r
+import rethinkdb as rdb
 from rethinkdb.errors import ReqlNonExistenceError
 
 from api.errors import ApiBadRequest
 
 from db.common import fetch_latest_block_num
 from db.common import parse_rules
+
+r = rdb.RethinkDB()
+
+print(">>> ", type(r))
+print(">>> ", dir(r))
 
 
 async def fetch_all_offer_resources(conn, query_params):


### PR DESCRIPTION
Trying to install sanic via pip tries to fetch the latest version. Latest version of the sanic requires a higher version of websockets that can't be installed to python 3.5 version.

Fixed version numbers for pip3 installs.