### PR TITLE
Archive repository

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -25,3 +25,4 @@ repository:
   allow_squash_merge: false
   allow_merge_commit: true
   allow_rebase_merge: true
+  archived: true


### PR DESCRIPTION
This change marks the repository as "archived" via the Github settings file.

This repo is no longer maintained and has been accreting security vulnerabilities due to outdated dependencies.

This will require approvals of all of the active maintainers.
